### PR TITLE
Update llm_provider.py for optional API Key Input

### DIFF
--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -23,11 +23,11 @@ class Provider:
             "huggingface": self.huggingface_fn
         }
         self.api_key = None
-        self.unsafe_providers = ["openai"]
+        self.unsafe_providers = ["openai", "ollama", "server", "huggingface"]
         if self.provider_name not in self.available_providers:
             raise ValueError(f"Unknown provider: {provider_name}")
         if self.provider_name in self.unsafe_providers:
-            print("Warning: you are using an API provider. You data will be sent to the cloud.")
+            print("Warning: you are using an API provider. You data will be sent to the cloud. If you chose ollama or server, then input anything for the API key (unless using programs like TabbyAPI that creates a unique API for locally run models)")
             self.get_api_key(self.provider_name)
         elif self.server != "":
             print("Provider initialized at ", self.server)


### PR DESCRIPTION
This will allow users who use different programs such as TabbyAPI to input their API key even when running locally hosted models.

NOTE: This should hopefully not break users using ollama, as the api key does not matter for them, all they would have to do is input anything, as shown in the new warning message.