### PR TITLE
ticket#204 on the upstream repo, allow containers to access config dir under SELinux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./frontend/agentic-seek-front/src:/app/src:z
+      - ./frontend/agentic-seek-front/src:/app/src:rw,z
       - ./screenshots:/app/screenshots
     environment:
       - NODE_ENV=development


### PR DESCRIPTION
Under SELinux enforcement, the searxng container was denied access to the bind-mounted ./searxng directory, the frontend container was also having issues causing permission errors. Adding the :z flag to the volume mount in docker-compose.yml applies the correct SELinux context for shared access.