### PR TITLE
Add support for ModelScope API

### DIFF
--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -333,7 +333,7 @@ class Provider:
             raise Exception("ModelScope (API) is not available for local use. Change config.ini")
         try:
             response = client.chat.completions.create(
-                model="Qwen/Qwen3-32B",
+                model="Qwen/Qwen3-235B-A22B",
                 messages=history,
                 stream=True,
                 extra_body=extra_body

--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -345,7 +345,6 @@ class Provider:
                     thought += answer_chunk
             if verbose:
                 print(thought)
-            print(thought)
             return thought
         except Exception as e:
             raise Exception(f"ModelScope API error: {str(e)}") from e


### PR DESCRIPTION
## Introduction
This PR is mainly to support [ModelScope API](https://modelscope.cn/docs/model-service/API-Inference/intro), and the supported models mainly include Qwen2.5 and Qwen3 series models.
And for more details about ModelScope API, please refer to this [link](https://modelscope.cn/docs/model-service/API-Inference/intro).

## Note
You need to bind your Alibaba Cloud account before using the API.