### PR TITLE
create work dir if not exists

### DIFF
--- a/api.py
+++ b/api.py
@@ -45,6 +45,8 @@ if not os.path.exists(".screenshots"):
 api.mount("/screenshots", StaticFiles(directory=".screenshots"), name="screenshots")
 
 def initialize_system():
+    if not os.path.exists(config["MAIN"]["work_dir"]):
+        os.makedirs(config["MAIN"]["work_dir"])
     stealth_mode = config.getboolean('BROWSER', 'stealth_mode')
     personality_folder = "jarvis" if config.getboolean('MAIN', 'jarvis_personality') else "base"
     languages = config["MAIN"]["languages"].split(' ')


### PR DESCRIPTION
When I start `api.py` with a **work_dir** that does not exist it throws warning repeatedly.

![Screenshot 2025-06-02 at 2 47 54 AM](https://github.com/user-attachments/assets/610b185c-3d2a-49c0-b442-281332303923)


Added helper code to remove those warnings.