### PR TITLE
Issue with Docker integrating with Searxng, mismatch between config a…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - ${WORK_DIR:-.}:/opt/workspace
     command: python3 api.py
     environment:
-      - SEARXNG_URL=${SEARXNG_BASE_URL:-http://searxng:8080}
+      - SEARXNG_BASE_URL=${SEARXNG_BASE_URL:-http://searxng:8080}
       - REDIS_URL=${REDIS_BASE_URL:-redis://redis:6379/0}
       - WORK_DIR=/opt/workspace
       - BACKEND_PORT=${BACKEND_PORT}


### PR DESCRIPTION
…nd code looking for SEARXNG_BASE_URL or SEARXING_URL

I think SEARXING_URL could maybe be a legacy or something from a different version. I see comments about SEARXING_PORT and SEARXNG_BIND_ADDRESS but they aren't used in the code anymore.