### PR TITLE
Headless chrome in a container

### DIFF
--- a/sources/browser.py
+++ b/sources/browser.py
@@ -121,6 +121,11 @@ def create_undetected_chromedriver(service, chrome_options) -> webdriver.Chrome:
 
 def create_driver(headless=False, stealth_mode=True, crx_path="./crx/nopecha.crx", lang="en") -> webdriver.Chrome:
     """Create a Chrome WebDriver with specified options."""
+    # Warn if trying to run non-headless in Docker
+    if not headless and os.path.exists('/.dockerenv'):
+        print("[WARNING] Running non-headless browser in Docker may fail!")
+        print("[WARNING] Consider setting headless=True or headless_browser=True in config.ini")
+    
     chrome_options = Options()
     chrome_path = get_chrome_path()
     


### PR DESCRIPTION
Added a warning for people that try to run a non-headless browser in a docker container. It errors in a very unhelpful way, and so this code tells the user in the output what's happening and also forces headless = True. If a user actually means to run a non-headless browser and view via X11 or something then the warning/output will lead them to the right place that they need to tweak.

Feel free to not use this code, but it could have saved me (and maybe someone else) a Saturday night. Haha