### PR TITLE
Enhance Memory class: Remove 'model_use' and 'time' in message payload when user use open router's free model

### DIFF
--- a/sources/memory.py
+++ b/sources/memory.py
@@ -7,9 +7,13 @@ import json
 from typing import List, Tuple, Type, Dict
 import torch
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+import configparser
 
 from sources.utility import timer_decorator, pretty_print, animate_thinking
 from sources.logger import Logger
+
+config = configparser.ConfigParser()
+config.read('config.ini')
 
 class Memory():
     """
@@ -162,7 +166,10 @@ class Memory():
         if self.memory[curr_idx-1]['content'] == content:
             pretty_print("Warning: same message have been pushed twice to memory", color="error")
         time_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        self.memory.append({'role': role, 'content': content, 'time': time_str, 'model_used': self.model_provider})
+        if config["MAIN"]["provider_name"] == "openrouter":
+            self.memory.append({'role': role, 'content': content})
+        else:
+            self.memory.append({'role': role, 'content': content, 'time': time_str, 'model_used': self.model_provider})
         return curr_idx-1
     
     def clear(self) -> None:


### PR DESCRIPTION
#345 
Removes the model_used and time parameters from the messages payload sent to OpenRouter. These parameters were causing 500 errors with free models (e.g., Mistral Devstral, Kimi) that do not ignore them. By excluding these parameters, we improve compatibility across OpenRouter’s diverse model offerings.

![image](https://github.com/user-attachments/assets/9b4c4b50-b9cd-4d94-b2f7-66ce1722ca38)
