### PR TITLE
fix: prioritize project root ChromeDriver for Docker compatibility

### DIFF
--- a/sources/browser.py
+++ b/sources/browser.py
@@ -80,18 +80,36 @@ def install_chromedriver() -> str:
     """
     Install the ChromeDriver if not already installed. Return the path.
     """
+    # First try to use chromedriver in the project root directory (as per README)
+    project_root_chromedriver = "./chromedriver"
+    if os.path.exists(project_root_chromedriver) and os.access(project_root_chromedriver, os.X_OK):
+        print(f"Using ChromeDriver from project root: {project_root_chromedriver}")
+        return project_root_chromedriver
+    
+    # Then try to use the system-installed chromedriver
     chromedriver_path = shutil.which("chromedriver")
-    if not chromedriver_path:
-        try:
-            print("ChromeDriver not found, attempting to install automatically...")
-            chromedriver_path = chromedriver_autoinstaller.install()
-        except Exception as e:
-            raise FileNotFoundError(
-                "ChromeDriver not found and could not be installed automatically. "
-                "Please install it manually from https://chromedriver.chromium.org/downloads."
-                "and ensure it's in your PATH or specify the path directly."
-                "See know issues in readme if your chrome version is above 115."
-            ) from e
+    if chromedriver_path:
+        return chromedriver_path
+    
+    # In Docker environment, try the fixed path
+    if os.path.exists('/.dockerenv'):
+        docker_chromedriver_path = "/usr/local/bin/chromedriver"
+        if os.path.exists(docker_chromedriver_path) and os.access(docker_chromedriver_path, os.X_OK):
+            print(f"Using Docker ChromeDriver at {docker_chromedriver_path}")
+            return docker_chromedriver_path
+    
+    # Fallback to auto-installer only if no other option works
+    try:
+        print("ChromeDriver not found, attempting to install automatically...")
+        chromedriver_path = chromedriver_autoinstaller.install()
+    except Exception as e:
+        raise FileNotFoundError(
+            "ChromeDriver not found and could not be installed automatically. "
+            "Please install it manually from https://chromedriver.chromium.org/downloads."
+            "and ensure it's in your PATH or specify the path directly."
+            "See know issues in readme if your chrome version is above 115."
+        ) from e
+    
     if not chromedriver_path:
         raise FileNotFoundError("ChromeDriver not found. Please install it or add it to your PATH.")
     return chromedriver_path


### PR DESCRIPTION
## 🛠️ Fix: ChromeDriver Detection Priority

This PR improves ChromeDriver detection logic to prioritize the project root directory, resolving compatibility issues with Docker environments using stealth mode.

### 🔧 What's Changed

**Modified `sources/browser.py` - `install_chromedriver()` function:**

1. **Project Root Priority**: Check `./chromedriver` first before system PATH
2. **Docker Detection**: Detect Docker environment and try Docker-specific paths  
3. **Debug Messages**: Add logging to show which ChromeDriver source is being used
4. **Fallback Logic**: Maintain existing auto-installer as last resort

### 🎯 Problem Solved

In Docker environments with stealth mode enabled, `undetected_chromedriver` bypasses the `Service` path and downloads its own ChromeDriver version. This causes version mismatches when the downloaded version doesn't match the container's Chrome version.

**Before:**
```bash
# ChromeDriver v138 auto-downloaded, but Chrome v134 in container
SessionNotCreatedException: This version of ChromeDriver only supports Chrome version 138
```
**After:**
```bash
# Uses correct ChromeDriver from project root
Using ChromeDriver from project root: ./chromedriver
INFO: Application startup complete.
```

### 🧪 Testing

- [x] Tested in Docker environment with stealth mode enabled
- [x] Verified project root ChromeDriver takes priority
- [x] Confirmed debug messages appear in logs
- [x] Maintains backward compatibility with existing installations
- [x] Backend starts successfully without version conflicts

### 📋 Implementation Details

- **Non-breaking change**: Existing installations continue to work
- **Enhanced debugging**: Clear messages show ChromeDriver source
- **Docker-aware**: Detects Docker environment for appropriate fallbacks
- **Follows README**: Aligns with the "project root directory" guidance