### PR TITLE
Replace bash shebang with unix agnostic variant

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPTS_DIR="scripts"
 LLM_ROUTER_DIR="llm_router"

--- a/llm_router/dl_safetensors.sh
+++ b/llm_router/dl_safetensors.sh
@@ -5,7 +5,7 @@
 # Therefore, I put all the files in llm_router and download the model file with this script, If you know a better way please raise an issue
 #########
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Define the URL and filename
 URL="https://huggingface.co/adaptive-classifier/llm-router/resolve/main/model.safetensors"

--- a/llm_server/install.sh
+++ b/llm_server/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 pip3 install --upgrade packaging
 pip3 install --upgrade pip setuptools

--- a/prompts/base/coder_agent.txt
+++ b/prompts/base/coder_agent.txt
@@ -19,7 +19,7 @@ toto.py
 
 You can execute bash command using the bash tag :
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 ls -la # example
 ```
 

--- a/prompts/jarvis/coder_agent.txt
+++ b/prompts/jarvis/coder_agent.txt
@@ -19,7 +19,7 @@ toto.py
 
 You can execute bash command using the bash tag :
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 ls -la # exemple
 ```
 

--- a/scripts/linux_install.sh
+++ b/scripts/linux_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Starting installation for Linux..."
 

--- a/scripts/macos_install.sh
+++ b/scripts/macos_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Starting installation for macOS..."
 

--- a/searxng/setup_searxng.sh
+++ b/searxng/setup_searxng.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to automate SearXNG setup and deployment with Docker Compose
 

--- a/start_services.sh
+++ b/start_services.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source .env
 


### PR DESCRIPTION
On some Unix Operating systems like mine (NixOS) the shebang `#!/bin/bash` does not work.
![image](https://github.com/user-attachments/assets/b7faf75c-9f59-4eb7-8153-d4e732746219)

The correct shebang to support all derivations is `#!/usr/bin/env bash`.