### PR TITLE
Fix backend url issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - ${WORK_DIR:-.}:/opt/workspace
     command: python3 api.py
     environment:
-      - SEARXNG_URL=${SEARXNG_BASE_URL:-http://searxng:8080}
+      - SEARXNG_BASE_URL=${SEARXNG_BASE_URL:-http://searxng:8080}
       - REDIS_URL=${REDIS_BASE_URL:-redis://redis:6379/0}
       - WORK_DIR=/opt/workspace
       - BACKEND_PORT=${BACKEND_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     environment:
       - SEARXNG_BASE_URL=${SEARXNG_BASE_URL:-http://localhost:8080/}
       - SEARXNG_SECRET_KEY=${SEARXNG_SECRET_KEY}
-      - UWSGI_WORKERS=5
+      - UWSGI_WORKERS=4
       - UWSGI_THREADS=4
     cap_add:
       - CHOWN
@@ -65,7 +65,7 @@ services:
     environment:
       - NODE_ENV=development
       - CHOKIDAR_USEPOLLING=true
-      - REACT_APP_BACKEND_URL=http://host.docker.internal:${BACKEND_PORT:-7777}
+      - REACT_APP_BACKEND_URL=http://localhost:7777
     networks:
       - agentic-seek-net
 
@@ -85,7 +85,7 @@ services:
       - ${WORK_DIR:-.}:/opt/workspace
     command: python3 api.py
     environment:
-      - SEARXNG_BASE_URL=${SEARXNG_BASE_URL:-http://searxng:8080}
+      - SEARXNG_URL=${SEARXNG_BASE_URL:-http://searxng:8080}
       - REDIS_URL=${REDIS_BASE_URL:-redis://redis:6379/0}
       - WORK_DIR=/opt/workspace
       - BACKEND_PORT=${BACKEND_PORT}

--- a/frontend/agentic-seek-front/src/App.js
+++ b/frontend/agentic-seek-front/src/App.js
@@ -6,9 +6,8 @@ import { ThemeToggle } from "./components/ThemeToggle";
 import { ResizableLayout } from "./components/ResizableLayout";
 import faviconPng from "./logo.png";
 
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:7777';
+const BACKEND_URL = 'http://localhost:7777' || process.env.REACT_APP_BACKEND_URL;
 console.log("Using backend URL:", BACKEND_URL);
-
 
 function App() {
   const [query, setQuery] = useState("");

--- a/frontend/agentic-seek-front/src/App.js
+++ b/frontend/agentic-seek-front/src/App.js
@@ -6,7 +6,7 @@ import { ThemeToggle } from "./components/ThemeToggle";
 import { ResizableLayout } from "./components/ResizableLayout";
 import faviconPng from "./logo.png";
 
-const BACKEND_URL = 'http://localhost:7777' || process.env.REACT_APP_BACKEND_URL;
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 console.log("Using backend URL:", BACKEND_URL);
 
 function App() {


### PR DESCRIPTION
Enforce frontend to use backend url http://localhost:7777, allowed since backend use "host.docker.internal:host-gateway" as extra-host.