### PR TITLE
add ollama service for linux (local)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,16 @@ services:
     networks:
       - agentic-seek-net
 
+  ollama:
+    container_name: ollama
+    image: ollama-with-model
+#    expose:
+#      - ${OLLAMA_PORT:-11434}
+    ports:
+      - ${OLLAMA_PORT:-11434}:${OLLAMA_PORT:-11434}
+    networks:
+      - agentic-seek-net
+
   backend:
     container_name: backend
     profiles: ["backend", "full"]
@@ -77,7 +87,7 @@ services:
       dockerfile: Dockerfile.backend
     ports:
       - ${BACKEND_PORT:-7777}:${BACKEND_PORT:-7777}
-      - ${OLLAMA_PORT:-11434}:${OLLAMA_PORT:-11434}
+#      - ${OLLAMA_PORT:-11434}:${OLLAMA_PORT:-11434}
       - ${LM_STUDIO_PORT:-1234}:${LM_STUDIO_PORT:-1234}
       - ${CUSTOM_ADDITIONAL_LLM_PORT:-8000}:${CUSTOM_ADDITIONAL_LLM_PORT:-8000}
     volumes:

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,10 @@
 
 SCRIPTS_DIR="scripts"
 LLM_ROUTER_DIR="llm_router"
+IS_LOCAL=$(grep "^is_local" config.ini | cut -d'=' -f2 | xargs)
+PROVIDER=$(grep "^provider_name" config.ini | cut -d'=' -f2 | xargs)
+MODEL=$(grep "^provider_model" config.ini | cut -d'=' -f2 | xargs)
+
 
 echo "Detecting operating system..."
 
@@ -19,6 +23,10 @@ case "$OS_TYPE" in
             echo "Error: $SCRIPTS_DIR/linux_install.sh not found!"
             exit 1
         fi
+	if [ "$IS_LOCAL" = "True" ] && [ "$PROVIDER" = "ollama" ]; then
+	    echo "Create ollama image with $MODEL model"
+	    bash "$SCRIPTS_DIR/ollama_install.sh" "$MODEL"
+	fi
         ;;
     "Darwin"*)
         echo "Detected macOS"

--- a/scripts/ollama_install.sh
+++ b/scripts/ollama_install.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+MODEL_NAME="$1"
+IMAGE_NAME="ollama-with-model"
+CONTAINER_NAME="ollama-temp"
+
+# Remove old container if exists
+if docker ps -a --format '{{.Names}}' | grep -q "^$CONTAINER_NAME$"; then
+    echo "Stopping and removing old container..."
+    docker stop $CONTAINER_NAME > /dev/null 2>&1 || true
+    docker rm $CONTAINER_NAME > /dev/null 2>&1
+fi
+
+# Remove old image if exists
+if docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "^$IMAGE_NAME:latest$"; then
+    echo "Removing old image: $IMAGE_NAME:latest..."
+    docker rmi $IMAGE_NAME:latest || echo "Could not remove image (possibly in use)"
+fi
+
+# Run the Ollama container
+echo "Running temporary container from ollama/ollama..."
+docker run -d --name $CONTAINER_NAME ollama/ollama
+
+# Wait for Ollama API to become available
+echo "Waiting for Ollama API to start..."
+for i in {1..30}; do
+    if docker exec $CONTAINER_NAME ollama list > /dev/null 2>&1; then
+        echo "Ollama is ready."
+        break
+    fi
+    echo "Attempt $i/30: Ollama is not ready yet..."
+    sleep 2
+done
+
+# Pull the model
+echo "Pulling model: $MODEL_NAME"
+if docker exec $CONTAINER_NAME ollama pull "$MODEL_NAME"; then
+    echo "Model '$MODEL_NAME' downloaded successfully."
+else
+    echo "Failed to pull model '$MODEL_NAME'"
+    docker stop $CONTAINER_NAME
+    docker rm $CONTAINER_NAME
+    exit 1
+fi
+
+# Commit container to a new image
+echo "Committing container to new image: $IMAGE_NAME:latest"
+docker commit $CONTAINER_NAME $IMAGE_NAME:latest
+
+# Cleanup
+echo "Stopping and removing temporary container..."
+docker stop $CONTAINER_NAME > /dev/null 2>&1
+docker rm $CONTAINER_NAME > /dev/null 2>&1
+docker image rm ollama/ollama
+
+# Done
+echo ""
+echo "Ollama image created"

--- a/start_services.sh
+++ b/start_services.sh
@@ -130,6 +130,15 @@ if [ "$1" = "full" ]; then
         echo "Possible fixes: Run with sudo or ensure port 8080 is free."
         exit 1
     fi
+    IS_LOCAL=$(grep "^is_local" config.ini | cut -d'=' -f2 | xargs)
+    PROVIDER_NAME=$(grep "^provider_name" config.ini | cut -d'=' -f2 | xargs)
+
+    if [ "$IS_LOCAL" = "True" ] && \
+       [ "$PROVIDER_NAME" = "ollama" ] && \
+       docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "^ollama-with-model:latest$"; then
+	echo "Starting ollama service"
+	$COMPOSE_CMD up -d ollama
+    fi
 else
     if ! $COMPOSE_CMD --profile core up; then
         echo "Error: Failed to start containers. Check Docker logs with '$COMPOSE_CMD logs'."


### PR DESCRIPTION
Only for Linux (when is_local = true and provider_name = ollama).

The install.sh script creates a Docker image by running a temporary Ollama container, pulling the specified model, and committing the container to an image.
The docker-compose.yml now includes a service that uses this image.