### PR TITLE
fix: return HTTP 500 instead of crashing server on query errors

### DIFF
--- a/api.py
+++ b/api.py
@@ -278,8 +278,11 @@ async def process_query(request: QueryRequest):
         return JSONResponse(status_code=200, content=query_resp.jsonify())
     except Exception as e:
         logger.error(f"An error occurred: {str(e)}")
-        sys.exit(1)
+        query_resp.answer = f"An error occurred: {str(e)}"
+        query_resp.reasoning = f"Error: {str(e)}"
+        return JSONResponse(status_code=500, content=query_resp.jsonify())
     finally:
+        is_generating = False
         logger.info("Processing finished")
         if config.getboolean('MAIN', 'save_session'):
             interaction.save_session()

--- a/sources/agents/planner_agent.py
+++ b/sources/agents/planner_agent.py
@@ -264,6 +264,8 @@ class PlannerAgent(Agent):
         agents_tasks = []
         required_infos = None
         agents_work_result = dict()
+        answer = ""
+        self.stop = False
 
         self.status_message = "Making a plan..."
         agents_tasks = await self.make_plan(goal)

--- a/sources/agents/planner_agent.py
+++ b/sources/agents/planner_agent.py
@@ -264,8 +264,6 @@ class PlannerAgent(Agent):
         agents_tasks = []
         required_infos = None
         agents_work_result = dict()
-        answer = ""
-        self.stop = False
 
         self.status_message = "Making a plan..."
         agents_tasks = await self.make_plan(goal)


### PR DESCRIPTION
Fixes #382

## Problem

When an exception occurs during query processing (e.g. LLM API error, malformed response, selenium error), `process_query` calls `sys.exit(1)` which **terminates the entire backend server process**. This causes the frontend to show "System offline. Deploy backend first." until the container is manually restarted.

Additionally, `is_generating` was only reset to `False` on the happy path (line after `think_wrapper`), so any exception would permanently lock the API into returning 429 for all subsequent requests — even if somehow the server survived.

Stack trace that leads to the crash:
```
ERROR:    Exception in ASGI application
...
except Exception as e:
    logger.error(f"An error occurred: {str(e)}")
    sys.exit(1)  # kills the entire server
```

## Solution

Two changes in `process_query`:

1. Replace `sys.exit(1)` with a proper HTTP 500 response so the server stays alive after errors
2. Move `is_generating = False` to the `finally` block so it always resets, regardless of success or failure

## Testing

- Trigger an intentional exception during query processing (e.g. use an invalid API key) and verify the server returns HTTP 500 but stays running
- Send a follow-up query and verify it is processed normally (not rejected with 429)