### PR TITLE
fix: use BACKEND_PORT env var in uvicorn and honor base_url arg in searxSearch

### DIFF
--- a/api.py
+++ b/api.py
@@ -299,4 +299,4 @@ if __name__ == "__main__":
         port = int(envport)
     else:
         port = 7777
-    uvicorn.run(api, host="0.0.0.0", port=7777)
+    uvicorn.run(api, host="0.0.0.0", port=port)

--- a/sources/tools/searxSearch.py
+++ b/sources/tools/searxSearch.py
@@ -1,5 +1,6 @@
 import requests
 from bs4 import BeautifulSoup
+import sys
 import os
 
 if __name__ == "__main__": # if running as a script for individual testing
@@ -16,7 +17,7 @@ class searxSearch(Tools):
         self.tag = "web_search"
         self.name = "searxSearch"
         self.description = "A tool for searching a SearxNG for web search"
-        self.base_url = os.getenv("SEARXNG_BASE_URL")  # Requires a SearxNG base URL
+        self.base_url = base_url or os.getenv("SEARXNG_BASE_URL")  # Requires a SearxNG base URL
         self.user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
         self.paywall_keywords = [
             "Member-only", "access denied", "restricted content", "404", "this page is not working"


### PR DESCRIPTION
## Problem

Two small but real bugs:

1. **`api.py`** — `uvicorn.run()` hardcodes `port=7777` instead of using the `port` variable that reads from `BACKEND_PORT`. Anyone setting `BACKEND_PORT=8888` in `.env` finds the API still listening on 7777 inside the container while Docker forwards 8888→8888, causing connection failures.

2. **`sources/tools/searxSearch.py`** — Two issues:
   - `import sys` is missing at the top of the file, causing `NameError: name 'sys' is not defined` when running the file as a standalone script (`python searxSearch.py`).
   - The `base_url` constructor argument is silently ignored — `self.base_url` is always set from the env var, so `searxSearch(base_url="http://...")` has no effect. The existing test in `tests/test_searx_search.py` calls `searxSearch(base_url=self.base_url)` expecting this to work.

## Solution

- `api.py`: change `port=7777` → `port=port` in `uvicorn.run()`
- `searxSearch.py`: add `import sys` and use `base_url or os.getenv("SEARXNG_BASE_URL")` so the constructor argument takes priority over the env var (matching the pattern used in `webSearch.py`)

## Testing

- Verified diff is minimal (3-line change across 2 files)
- `tests/test_searx_search.py` `test_initialization_with_env_variable` and `test_initialization_no_base_url` still pass with the fix