### PR TITLE
fix: make REACT_APP_BACKEND_URL configurable for remote deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ WORK_DIR="/Users/username/Documents/workspace_with_my_files"
 OLLAMA_PORT="11434"
 LM_STUDIO_PORT="1234"
 BACKEND_PORT="7777"
+# Set this to your server's public IP/hostname when accessing the UI from a remote machine.
+# Example: REACT_APP_BACKEND_URL=http://192.168.1.100:7777
+REACT_APP_BACKEND_URL=http://localhost:7777
 CUSTOM_ADDITIONAL_LLM_PORT="11435"
 OPENAI_API_KEY='xxxxx'
 DEEPSEEK_API_KEY='xxxxx'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     environment:
       - NODE_ENV=development
       - CHOKIDAR_USEPOLLING=true
-      - REACT_APP_BACKEND_URL=http://localhost:7777
+      - REACT_APP_BACKEND_URL=${REACT_APP_BACKEND_URL:-http://localhost:7777}
     networks:
       - agentic-seek-net
 


### PR DESCRIPTION
Fixes #352

## Problem

When AgenticSeek is deployed on a remote server (e.g. a VPS, cloud instance, or NAS) and users open the frontend from a different machine, the browser's JavaScript tries to reach `http://localhost:7777` — which resolves to the **user's local machine**, not the server running Docker. The health-check fails and the UI shows **"System offline. Deploy backend first."** even though the backend is running perfectly.

This is the root cause of several reports in #352, #383, and #372 where the backend logs show a healthy startup but the web UI still shows offline.

## Root Cause

`docker-compose.yml` hardcodes `REACT_APP_BACKEND_URL=http://localhost:7777`. Since React bakes this URL into the compiled JavaScript bundle at dev-server startup, there was previously no way to override it without editing `docker-compose.yml` directly.

## Solution

- **`docker-compose.yml`**: Read `REACT_APP_BACKEND_URL` from the `.env` file with a default of `http://localhost:7777`, so local setups keep working out of the box.
- **`.env.example`**: Document the variable so users are aware they can change it. Users deploying on a remote server simply set `REACT_APP_BACKEND_URL=http://<server-ip>:7777` in their `.env` and restart the Docker stack.

## Testing

- Default behaviour unchanged: if `REACT_APP_BACKEND_URL` is not set in `.env`, it defaults to `http://localhost:7777`.
- Remote deployment: set `REACT_APP_BACKEND_URL=http://192.168.1.100:7777` in `.env`, run `./start_services.sh full`, open `http://192.168.1.100:3000` from another machine — the status indicator now shows **Online**.