### PR TITLE
fix: use configured port from server_address for local Ollama connections

### DIFF
--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -165,7 +165,11 @@ class Provider:
         Use local or remote Ollama server to generate text.
         """
         thought = ""
-        host = f"{self.internal_url}:11434" if self.is_local else f"http://{self.server_address}"
+        if self.is_local:
+            server_port = self.server_address.split(":")[-1] if ":" in str(self.server_address) else "11434"
+            host = f"{self.internal_url}:{server_port}"
+        else:
+            host = f"http://{self.server_address}"
         client = OllamaClient(host=host)
 
         try:


### PR DESCRIPTION
Fixes #332

## Problem
When `is_local=True`, the Ollama connection URL hardcoded port `11434` regardless of what was set in `provider_server_address` in `config.ini`. Users who need Ollama on a different port (e.g. because port 11434 is already in use by another process) had no way to configure this without modifying source code.

## Solution
Extract the port from `provider_server_address` when `is_local=True` and use it to construct the Ollama host URL. Falls back to the default port `11434` when only a hostname (no port) is given.

**Before:**
```python
host = f"{self.internal_url}:11434" if self.is_local else f"http://{self.server_address}"
```

**After:**
```python
if self.is_local:
    server_port = self.server_address.split(":")[-1] if ":" in str(self.server_address) else "11434"
    host = f"{self.internal_url}:{server_port}"
else:
    host = f"http://{self.server_address}"
```

Now users can set `provider_server_address = 127.0.0.1:11435` in `config.ini` if port `11434` is already in use, and the connection will use the configured port.

## Testing
- Existing behaviour preserved: default config `127.0.0.1:11434` still connects on port 11434
- Custom port: setting `provider_server_address = 127.0.0.1:11435` now correctly connects on port 11435
- Hostname-only address: `127.0.0.1` (no colon) falls back to port 11434