### PR TITLE
fix: URL-encode search query and detect empty results as failure

### DIFF
--- a/sources/tools/searxSearch.py
+++ b/sources/tools/searxSearch.py
@@ -1,6 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
 import os
+from urllib.parse import urlencode
 
 if __name__ == "__main__": # if running as a script for individual testing
     sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
@@ -77,7 +78,14 @@ class searxSearch(Tools):
             'Upgrade-Insecure-Requests': '1',
             'User-Agent': self.user_agent
         }
-        data = f"q={query}&categories=general&language=auto&time_range=&safesearch=0&theme=simple".encode('utf-8')
+        data = urlencode({
+            'q': query,
+            'categories': 'general',
+            'language': 'auto',
+            'time_range': '',
+            'safesearch': '0',
+            'theme': 'simple'
+        }).encode('utf-8')
         try:
             response = requests.post(search_url, headers=headers, data=data, verify=False)
             response.raise_for_status()
@@ -101,7 +109,7 @@ class searxSearch(Tools):
         """
         Checks if the execution failed based on the output.
         """
-        return "Error" in output
+        return "Error" in output or "No search results" in output
 
     def interpreter_feedback(self, output: str) -> str:
         """


### PR DESCRIPTION
Fixes #274

## Problem

`searxSearch.execute()` builds the POST body using a raw f-string without URL-encoding the query value:

```python
# Before (broken)
data = f"q={query}&categories=general&...".encode('utf-8')
```

This means any query containing characters like `&`, `+`, `=`, or spaces encoded as `%20` is silently mangled before being sent to SearXNG. For example, a query `A & B` becomes `q=A & B&categories=...`, which breaks the form data and causes SearXNG to receive a malformed or empty query — resulting in zero results.

Additionally, `execution_failure_check` only checks for the word `"Error"` in the output, so the message `"No search results, web search failed."` was not recognized as a failure. This caused the agent to treat an empty result set as a successful search and loop indefinitely trying to act on no data.

## Solution

1. Replace the raw f-string with `urllib.parse.urlencode`, which properly percent-encodes all special characters in the query.
2. Add `"No search results"` to the failure check so the agent correctly identifies and reports search failures when all SearXNG engines are unavailable or rate-limited.

## Testing

- Manually verified that `urlencode({'q': 'A & B', ...})` produces `q=A+%26+B&...`, which is correctly parsed by SearXNG.
- The `execution_failure_check` unit tests in `tests/test_searx_search.py` continue to pass; the new condition also correctly flags the `"No search results"` string.