### PR TITLE
fix: correct LM Studio URL parsing and uvicorn port binding

### DIFF
--- a/api.py
+++ b/api.py
@@ -299,4 +299,4 @@ if __name__ == "__main__":
         port = int(envport)
     else:
         port = 7777
-    uvicorn.run(api, host="0.0.0.0", port=7777)
+    uvicorn.run(api, host="0.0.0.0", port=port)

--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -344,13 +344,21 @@ class Provider:
         Use local lm-studio server to generate text.
         """
         if self.in_docker:
-            # Extract port from server_address if present
+            # Extract port from server_address, handling both "host:port" and "http://host:port"
             port = "1234"  # default
-            if ":" in self.server_address:
-                port = self.server_address.split(":")[1]
+            addr = self.server_address
+            if "://" not in addr:
+                addr = f"http://{addr}"
+            parsed_addr = urlparse(addr)
+            if parsed_addr.port:
+                port = str(parsed_addr.port)
             url = f"{self.internal_url}:{port}"
         else:
-            url = f"http://{self.server_ip}"
+            # Normalize the address to ensure it has a scheme prefix
+            addr = self.server_ip
+            if "://" not in addr:
+                addr = f"http://{addr}"
+            url = addr
         route_start = f"{url}/v1/chat/completions"
         payload = {
             "messages": history,


### PR DESCRIPTION
Fixes #394

## Problem

Two related bugs affecting users who configure LM Studio with a full URL (as recommended in the README):

**1. LM Studio URL parsing breaks in Docker when `http://` prefix is present**

The README explicitly states:
> Some provider (eg: lm-studio) require you to have `http://` in front of the IP. For example `http://127.0.0.1:1234`

However, in `lm_studio_fn`, when running in Docker, the code extracted the port with:
```python
port = self.server_address.split(":")[1]
```
For `http://127.0.0.1:1234`, `split(":")[1]` returns `"//127.0.0.1"` (the second colon-delimited segment) instead of `"1234"`, producing a malformed URL like `http://host.docker.internal://127.0.0.1` and causing the connection to fail.

The non-Docker path had the same issue in reverse: `f"http://{self.server_ip}"` would produce `http://http://127.0.0.1:1234` when the address already includes a scheme.

**2. BACKEND_PORT environment variable ignored by uvicorn**

`api.py` computed `port` from the `BACKEND_PORT` env var but then called `uvicorn.run(api, host="0.0.0.0", port=7777)` — hardcoding 7777 and discarding the computed value. This means the server always binds to port 7777 regardless of what `BACKEND_PORT` is set to.

## Solution

- **`sources/llm_provider.py`**: Use `urlparse` to reliably extract the port from `server_address`, correctly handling both `host:port` and `http://host:port` formats. Normalise the non-Docker path to strip/add the `http://` scheme exactly once.
- **`api.py`**: Pass the computed `port` variable to `uvicorn.run()` instead of the literal `7777`.

## Testing

- Verified with `provider_server_address = http://127.0.0.1:1234`: port is now correctly extracted as `1234`.
- Verified with `provider_server_address = 127.0.0.1:1234` (no scheme): port still correctly extracted as `1234`.
- `BACKEND_PORT=8888` now results in uvicorn binding to port 8888.