### PR TITLE
fix: read Redis URL from environment variables for Docker deployment (fixes #385)

### DIFF
--- a/api.py
+++ b/api.py
@@ -46,7 +46,8 @@ def is_running_in_docker():
 from celery import Celery
 
 api = FastAPI(title="AgenticSeek API", version="0.1.0")
-celery_app = Celery("tasks", broker="redis://localhost:6379/0", backend="redis://localhost:6379/0")
+_redis_url = os.environ.get("REDIS_URL", os.environ.get("REDIS_BASE_URL", "redis://localhost:6379/0"))
+celery_app = Celery("tasks", broker=_redis_url, backend=_redis_url)
 celery_app.conf.update(task_track_started=True)
 logger = Logger("backend.log")
 config = configparser.ConfigParser()


### PR DESCRIPTION
Fixes #385

## Problem

The Celery broker and backend URLs were hardcoded to `redis://localhost:6379/0` in `api.py`:

```python
celery_app = Celery("tasks", broker="redis://localhost:6379/0", backend="redis://localhost:6379/0")
```

When running in Docker, the Redis service is reachable at `redis://redis:6379/0` (via the Docker network using the service name), not `localhost`. The `docker-compose.yml` already correctly passes `REDIS_URL=${REDIS_BASE_URL:-redis://redis:6379/0}` as an environment variable to the backend container, but the code was ignoring it entirely.

This causes the backend container to silently fail to connect to Redis during startup, resulting in the symptom reported in #385: the container shows `Device set to use cpu` and then never reaches the Uvicorn startup logs.

## Solution

Read the Redis URL from environment variables before falling back to `localhost`:

1. `REDIS_URL` — set by `docker-compose.yml` for Docker deployments
2. `REDIS_BASE_URL` — the user-facing variable name documented in `.env.example`
3. `redis://localhost:6379/0` — fallback for local (non-Docker) development

```python
_redis_url = os.environ.get("REDIS_URL", os.environ.get("REDIS_BASE_URL", "redis://localhost:6379/0"))
celery_app = Celery("tasks", broker=_redis_url, backend=_redis_url)
```

## Testing

- Local development: no change in behaviour (falls back to `localhost`)
- Docker deployment: `REDIS_URL=redis://redis:6379/0` is picked up from the environment, matching the existing `docker-compose.yml` configuration