### PR TITLE
fix: raise ValueError instead of exit(1) on missing API key; return error string from searxSearch on network failure

### DIFF
--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -59,8 +59,10 @@ class Provider:
         api_key_var = f"{provider.upper()}_API_KEY"
         api_key = os.getenv(api_key_var)
         if not api_key:
-            pretty_print(f"API key {api_key_var} not found in .env file. Please add it", color="warning")
-            exit(1)
+            raise ValueError(
+                f"API key {api_key_var} not found in .env file. "
+                "Please add it to your .env file and restart the server."
+            )
         return api_key
     
     def get_internal_url(self):

--- a/sources/tools/searxSearch.py
+++ b/sources/tools/searxSearch.py
@@ -104,7 +104,7 @@ class searxSearch(Tools):
                 return "No search results, web search failed."
             return "\n\n".join(results)  # Return results as a single string, separated by newlines
         except requests.exceptions.RequestException as e:
-            raise Exception("\nSearxng search failed. did you run start_services.sh? is docker still running?") from e
+            return f"Error during search: SearxNG unavailable. Did you run start_services.sh? Is Docker still running? ({str(e)})"
 
     def execution_failure_check(self, output: str) -> bool:
         """


### PR DESCRIPTION
## Problem

Two related error-handling bugs crash the backend or break the tool contract:

1. **`Provider.get_api_key()` calls `exit(1)` when the API key is missing** (`sources/llm_provider.py:63`). This terminates the entire backend process immediately — including when running inside Docker — instead of surfacing a clear error. Users then see the WebUI as offline with no useful diagnostics.

2. **`searxSearch.execute()` raises an `Exception` on `RequestException`** (`sources/tools/searxSearch.py:107`). All other `execute()` implementations return an error string; raising here breaks the tool API contract assumed by `execute_modules()` in `agent.py`, crashes the agent mid-task, and also causes `test_execute_request_exception` to fail (the test correctly expects a return value).

## Solution

- Replace `exit(1)` in `get_api_key()` with `raise ValueError(...)` so callers receive a proper Python exception with a descriptive message rather than a silent process crash.
- Replace the `raise Exception(...)` in `searxSearch.execute()` with a `return` of an error string (prefixed with `"Error during search:"` so `execution_failure_check()` detects it correctly).

## Testing

- `python -m pytest tests/test_searx_search.py` — all 9 tests pass, including `test_execute_request_exception` which now correctly receives an error string instead of an unhandled exception.
- `python -m pytest tests/` — only the pre-existing `test_save_and_load_memory` failure remains (caused by a `termcolor<2.4.0` installation in the test environment, unrelated to this PR).