### PR TITLE
fix: remove duplicate soundfile entry in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ transformers>=4.46.3
 torch>=2.4.1
 ollama>=0.4.7
 scipy>=1.9.3
-soundfile>=0.13.1
 protobuf>=3.20.3
 termcolor>=2.4.0
 pypdf>=5.4.0


### PR DESCRIPTION
Closes #471

## Problem

`requirements.txt` contains two identical entries for `soundfile>=0.13.1` (one at line 16, one near line 21). This causes `pip install` to emit warnings and can result in version-resolution confusion in environments that process dependencies strictly.

## Fix

Remove the duplicate entry, keeping exactly one `soundfile>=0.13.1` line.