### PR TITLE
fix: add missing comma in unsafe_commands_unix to prevent silent safety bypass

### DIFF
--- a/sources/tools/safety.py
+++ b/sources/tools/safety.py
@@ -28,7 +28,7 @@ unsafe_commands_unix = [
     "fdisk",        # Disk partitioning
     "parted",       # Disk partitioning
     "chroot",       # Change root directory
-    "route"         # Routing table management
+    "route",        # Routing table management
     "--force",     # Force flag for many commands
     "rebase",     # Rebase git repository
     "git" # Git commands


### PR DESCRIPTION
## Problem

In `sources/tools/safety.py`, a missing comma between `"route"` and `"--force"` in the `unsafe_commands_unix` list causes Python's implicit string concatenation to merge them into the single string `"route--force"`:

```python
# Before (bug): adjacent string literals concatenated
"route"         # Routing table management
"--force",     # Force flag for many commands
```

This means `is_unsafe()` returns `False` for commands containing `route` or `--force`, silently bypassing two safety checks:

```python
>>> is_unsafe("route -n")  # should be True
False
>>> is_unsafe("git push --force")  # should be True
False
```

## Solution

Add the missing comma after `"route"`:

```python
"route",        # Routing table management
"--force",     # Force flag for many commands
```

## Testing

```python
>>> from sources.tools.safety import is_unsafe
>>> is_unsafe("route -n")
True
>>> is_unsafe("git push --force")
True
>>> is_unsafe("ls -la")
False
```