### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ undetected-chromedriver>=3.5.5
 sentencepiece>=0.2.0
 together>=1.5.0
 tqdm>4
+litellm>=1.55,<1.85
 openai
 sniffio
 ordered_set

--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -43,7 +43,7 @@ class Provider:
         self.logger = Logger("provider.log")
         self.api_key = None
         self.internal_url, self.in_docker = self.get_internal_url()
-        self.unsafe_providers = ["openai", "deepseek", "dsk_deepseek", "together", "google", "openrouter", "anthropic", "minimax", "litellm"]
+        self.unsafe_providers = ["openai", "deepseek", "dsk_deepseek", "together", "google", "openrouter", "anthropic", "minimax"]
         if self.provider_name not in self.available_providers:
             raise ValueError(f"Unknown provider: {provider_name}")
         if self.provider_name in self.unsafe_providers and self.is_local == False:
@@ -513,13 +513,17 @@ class Provider:
         if self.is_local:
             raise Exception("LiteLLM is not available for local use. Change config.ini")
 
+        api_key = os.getenv("LITELLM_API_KEY", None)
+
         try:
-            response = litellm.completion(
-                model=self.model,
-                messages=history,
-                api_key=self.api_key,
-                drop_params=True,
-            )
+            call_kwargs = {
+                "model": self.model,
+                "messages": history,
+                "drop_params": True,
+            }
+            if api_key:
+                call_kwargs["api_key"] = api_key
+            response = litellm.completion(**call_kwargs)
             if response is None:
                 raise Exception("LiteLLM response is empty.")
             thought = response.choices[0].message.content

--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -510,6 +510,9 @@ class Provider:
         except ImportError as e:
             raise ImportError("litellm is not installed. Install with: pip install litellm") from e
 
+        if self.is_local:
+            raise Exception("LiteLLM is not available for local use. Change config.ini")
+
         try:
             response = litellm.completion(
                 model=self.model,

--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -37,12 +37,13 @@ class Provider:
             "openrouter": self.openrouter_fn,
             "anthropic": self.anthropic_fn,
             "minimax": self.minimax_fn,
+            "litellm": self.litellm_fn,
             "test": self.test_fn
         }
         self.logger = Logger("provider.log")
         self.api_key = None
         self.internal_url, self.in_docker = self.get_internal_url()
-        self.unsafe_providers = ["openai", "deepseek", "dsk_deepseek", "together", "google", "openrouter", "anthropic", "minimax"]
+        self.unsafe_providers = ["openai", "deepseek", "dsk_deepseek", "together", "google", "openrouter", "anthropic", "minimax", "litellm"]
         if self.provider_name not in self.available_providers:
             raise ValueError(f"Unknown provider: {provider_name}")
         if self.provider_name in self.unsafe_providers and self.is_local == False:
@@ -496,6 +497,34 @@ class Provider:
         except APIError as e:
             raise APIError(f"API error occurred: {str(e)}") from e
         return None
+
+    def litellm_fn(self, history, verbose=False):
+        """
+        Use LiteLLM AI gateway for completion.
+        Routes to 100+ providers (OpenAI, Anthropic, Azure, Bedrock,
+        Vertex AI, Groq, Together, Ollama, etc.) based on model prefix.
+        See https://docs.litellm.ai/docs/providers
+        """
+        try:
+            import litellm
+        except ImportError as e:
+            raise ImportError("litellm is not installed. Install with: pip install litellm") from e
+
+        try:
+            response = litellm.completion(
+                model=self.model,
+                messages=history,
+                api_key=self.api_key,
+                drop_params=True,
+            )
+            if response is None:
+                raise Exception("LiteLLM response is empty.")
+            thought = response.choices[0].message.content
+            if verbose:
+                print(thought)
+            return thought
+        except Exception as e:
+            raise Exception(f"LiteLLM API error: {str(e)}") from e
 
     def test_fn(self, history, verbose=True):
         """

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -30,6 +30,15 @@ class TestLiteLLMProvider(unittest.TestCase):
             mock_get_key.assert_called_with("litellm")
             self.assertEqual(provider.api_key, 'test-litellm-key')
 
+    def test_litellm_local_not_supported(self):
+        """Test that litellm provider raises error when is_local=True."""
+        provider = Provider("litellm", "gpt-4o-mini", is_local=True)
+        provider.api_key = 'test-key'
+        history = [{"role": "user", "content": "Hello"}]
+        with self.assertRaises(Exception) as context:
+            provider.litellm_fn(history)
+        self.assertIn("not available for local use", str(context.exception))
+
     @patch('litellm.completion')
     def test_litellm_fn_returns_content(self, mock_completion):
         """Test that litellm_fn returns response content."""

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,113 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sources.llm_provider import Provider
+
+
+class TestLiteLLMProvider(unittest.TestCase):
+    """Test cases for LiteLLM provider integration."""
+
+    def test_litellm_provider_registered(self):
+        """Test that litellm provider is registered in available_providers."""
+        with patch.object(Provider, 'get_api_key', return_value='test-key'):
+            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+            self.assertIn("litellm", provider.available_providers)
+
+    def test_litellm_in_unsafe_providers(self):
+        """Test that litellm is in unsafe_providers list."""
+        with patch.object(Provider, 'get_api_key', return_value='test-key'):
+            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+            self.assertIn("litellm", provider.unsafe_providers)
+
+    def test_litellm_api_key_required(self):
+        """Test that API key is fetched for litellm provider."""
+        with patch.object(Provider, 'get_api_key', return_value='test-litellm-key') as mock_get_key:
+            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+            mock_get_key.assert_called_with("litellm")
+            self.assertEqual(provider.api_key, 'test-litellm-key')
+
+    @patch('litellm.completion')
+    def test_litellm_fn_returns_content(self, mock_completion):
+        """Test that litellm_fn returns response content."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="42"))]
+        mock_completion.return_value = mock_response
+
+        with patch.object(Provider, 'get_api_key', return_value='test-key'):
+            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+            history = [{"role": "user", "content": "What is 2+2?"}]
+            result = provider.litellm_fn(history)
+
+        self.assertEqual(result, "42")
+
+    @patch('litellm.completion')
+    def test_litellm_fn_passes_drop_params(self, mock_completion):
+        """Test that litellm_fn sets drop_params=True."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"))]
+        mock_completion.return_value = mock_response
+
+        with patch.object(Provider, 'get_api_key', return_value='test-key'):
+            provider = Provider("litellm", "anthropic/claude-sonnet-4", is_local=False)
+            provider.litellm_fn([{"role": "user", "content": "hi"}])
+
+        call_kwargs = mock_completion.call_args[1]
+        self.assertTrue(call_kwargs["drop_params"])
+
+    @patch('litellm.completion')
+    def test_litellm_fn_passes_model(self, mock_completion):
+        """Test that litellm_fn passes the correct model string."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"))]
+        mock_completion.return_value = mock_response
+
+        with patch.object(Provider, 'get_api_key', return_value='test-key'):
+            provider = Provider("litellm", "anthropic/claude-sonnet-4", is_local=False)
+            provider.litellm_fn([{"role": "user", "content": "hi"}])
+
+        call_kwargs = mock_completion.call_args[1]
+        self.assertEqual(call_kwargs["model"], "anthropic/claude-sonnet-4")
+
+    @patch('litellm.completion')
+    def test_litellm_fn_passes_api_key(self, mock_completion):
+        """Test that litellm_fn forwards the API key."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"))]
+        mock_completion.return_value = mock_response
+
+        with patch.object(Provider, 'get_api_key', return_value='sk-test-123'):
+            provider = Provider("litellm", "gpt-4o", is_local=False)
+            provider.litellm_fn([{"role": "user", "content": "hi"}])
+
+        call_kwargs = mock_completion.call_args[1]
+        self.assertEqual(call_kwargs["api_key"], "sk-test-123")
+
+    @patch('litellm.completion')
+    def test_litellm_fn_raises_on_empty_response(self, mock_completion):
+        """Test that litellm_fn raises on empty response."""
+        mock_completion.return_value = None
+
+        with patch.object(Provider, 'get_api_key', return_value='test-key'):
+            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+            with self.assertRaises(Exception) as ctx:
+                provider.litellm_fn([{"role": "user", "content": "hi"}])
+            self.assertIn("empty", str(ctx.exception).lower())
+
+    @patch('litellm.completion')
+    def test_litellm_fn_raises_on_api_error(self, mock_completion):
+        """Test that litellm_fn wraps API errors."""
+        mock_completion.side_effect = Exception("rate limit exceeded")
+
+        with patch.object(Provider, 'get_api_key', return_value='test-key'):
+            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+            with self.assertRaises(Exception) as ctx:
+                provider.litellm_fn([{"role": "user", "content": "hi"}])
+            self.assertIn("LiteLLM API error", str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -13,27 +13,22 @@ class TestLiteLLMProvider(unittest.TestCase):
 
     def test_litellm_provider_registered(self):
         """Test that litellm provider is registered in available_providers."""
-        with patch.object(Provider, 'get_api_key', return_value='test-key'):
-            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
-            self.assertIn("litellm", provider.available_providers)
+        provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+        self.assertIn("litellm", provider.available_providers)
 
-    def test_litellm_in_unsafe_providers(self):
-        """Test that litellm is in unsafe_providers list."""
-        with patch.object(Provider, 'get_api_key', return_value='test-key'):
-            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
-            self.assertIn("litellm", provider.unsafe_providers)
+    def test_litellm_not_in_unsafe_providers(self):
+        """LiteLLM is not in unsafe_providers because it resolves API keys itself."""
+        provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+        self.assertNotIn("litellm", provider.unsafe_providers)
 
-    def test_litellm_api_key_required(self):
-        """Test that API key is fetched for litellm provider."""
-        with patch.object(Provider, 'get_api_key', return_value='test-litellm-key') as mock_get_key:
-            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
-            mock_get_key.assert_called_with("litellm")
-            self.assertEqual(provider.api_key, 'test-litellm-key')
+    def test_litellm_no_api_key_required_at_init(self):
+        """LiteLLM does not require LITELLM_API_KEY at init."""
+        provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+        self.assertIsNone(provider.api_key)
 
     def test_litellm_local_not_supported(self):
         """Test that litellm provider raises error when is_local=True."""
         provider = Provider("litellm", "gpt-4o-mini", is_local=True)
-        provider.api_key = 'test-key'
         history = [{"role": "user", "content": "Hello"}]
         with self.assertRaises(Exception) as context:
             provider.litellm_fn(history)
@@ -46,10 +41,9 @@ class TestLiteLLMProvider(unittest.TestCase):
         mock_response.choices = [MagicMock(message=MagicMock(content="42"))]
         mock_completion.return_value = mock_response
 
-        with patch.object(Provider, 'get_api_key', return_value='test-key'):
-            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
-            history = [{"role": "user", "content": "What is 2+2?"}]
-            result = provider.litellm_fn(history)
+        provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+        history = [{"role": "user", "content": "What is 2+2?"}]
+        result = provider.litellm_fn(history)
 
         self.assertEqual(result, "42")
 
@@ -60,9 +54,8 @@ class TestLiteLLMProvider(unittest.TestCase):
         mock_response.choices = [MagicMock(message=MagicMock(content="ok"))]
         mock_completion.return_value = mock_response
 
-        with patch.object(Provider, 'get_api_key', return_value='test-key'):
-            provider = Provider("litellm", "anthropic/claude-sonnet-4", is_local=False)
-            provider.litellm_fn([{"role": "user", "content": "hi"}])
+        provider = Provider("litellm", "anthropic/claude-sonnet-4", is_local=False)
+        provider.litellm_fn([{"role": "user", "content": "hi"}])
 
         call_kwargs = mock_completion.call_args[1]
         self.assertTrue(call_kwargs["drop_params"])
@@ -74,48 +67,59 @@ class TestLiteLLMProvider(unittest.TestCase):
         mock_response.choices = [MagicMock(message=MagicMock(content="ok"))]
         mock_completion.return_value = mock_response
 
-        with patch.object(Provider, 'get_api_key', return_value='test-key'):
-            provider = Provider("litellm", "anthropic/claude-sonnet-4", is_local=False)
-            provider.litellm_fn([{"role": "user", "content": "hi"}])
+        provider = Provider("litellm", "anthropic/claude-sonnet-4", is_local=False)
+        provider.litellm_fn([{"role": "user", "content": "hi"}])
 
         call_kwargs = mock_completion.call_args[1]
         self.assertEqual(call_kwargs["model"], "anthropic/claude-sonnet-4")
 
+    @patch.dict(os.environ, {"LITELLM_API_KEY": "sk-test-123"})
     @patch('litellm.completion')
-    def test_litellm_fn_passes_api_key(self, mock_completion):
-        """Test that litellm_fn forwards the API key."""
+    def test_litellm_fn_passes_api_key_from_env(self, mock_completion):
+        """Test that litellm_fn forwards LITELLM_API_KEY when set."""
         mock_response = MagicMock()
         mock_response.choices = [MagicMock(message=MagicMock(content="ok"))]
         mock_completion.return_value = mock_response
 
-        with patch.object(Provider, 'get_api_key', return_value='sk-test-123'):
-            provider = Provider("litellm", "gpt-4o", is_local=False)
-            provider.litellm_fn([{"role": "user", "content": "hi"}])
+        provider = Provider("litellm", "gpt-4o", is_local=False)
+        provider.litellm_fn([{"role": "user", "content": "hi"}])
 
         call_kwargs = mock_completion.call_args[1]
         self.assertEqual(call_kwargs["api_key"], "sk-test-123")
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch('litellm.completion')
+    def test_litellm_fn_omits_api_key_when_not_set(self, mock_completion):
+        """Test that litellm_fn omits api_key when LITELLM_API_KEY is not set."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"))]
+        mock_completion.return_value = mock_response
+
+        provider = Provider("litellm", "gpt-4o", is_local=False)
+        provider.litellm_fn([{"role": "user", "content": "hi"}])
+
+        call_kwargs = mock_completion.call_args[1]
+        self.assertNotIn("api_key", call_kwargs)
 
     @patch('litellm.completion')
     def test_litellm_fn_raises_on_empty_response(self, mock_completion):
         """Test that litellm_fn raises on empty response."""
         mock_completion.return_value = None
 
-        with patch.object(Provider, 'get_api_key', return_value='test-key'):
-            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
-            with self.assertRaises(Exception) as ctx:
-                provider.litellm_fn([{"role": "user", "content": "hi"}])
-            self.assertIn("empty", str(ctx.exception).lower())
+        provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+        with self.assertRaises(Exception) as ctx:
+            provider.litellm_fn([{"role": "user", "content": "hi"}])
+        self.assertIn("empty", str(ctx.exception).lower())
 
     @patch('litellm.completion')
     def test_litellm_fn_raises_on_api_error(self, mock_completion):
         """Test that litellm_fn wraps API errors."""
         mock_completion.side_effect = Exception("rate limit exceeded")
 
-        with patch.object(Provider, 'get_api_key', return_value='test-key'):
-            provider = Provider("litellm", "gpt-4o-mini", is_local=False)
-            with self.assertRaises(Exception) as ctx:
-                provider.litellm_fn([{"role": "user", "content": "hi"}])
-            self.assertIn("LiteLLM API error", str(ctx.exception))
+        provider = Provider("litellm", "gpt-4o-mini", is_local=False)
+        with self.assertRaises(Exception) as ctx:
+            provider.litellm_fn([{"role": "user", "content": "hi"}])
+        self.assertIn("LiteLLM API error", str(ctx.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                          
  Adds [LiteLLM](https://github.com/BerriAI/litellm) as a provider gateway, enabling access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Groq, Together, Ollama, etc.) through a single unified interface via `litellm.completion()`.                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
  Users can set `provider_name = litellm` in `config.ini` with any LiteLLM model string to route to any supported provider without needing provider-specific code.                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                          
  ## Changes                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                          
  - `sources/llm_provider.py` -- added `litellm_fn` method and registered `"litellm"` in `available_providers`.                                                                                                                                                                                                                             
  - `requirements.txt` -- added `litellm>=1.55,<1.85`                                                                                                                                                                                                                                                                                                                     
  - `tests/test_litellm_provider.py` -- 11 unit tests                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                          
  Key details:                                                                                                                                                                                                                                                                                                                                                            
  - `drop_params=True` by default -- silently drops provider-unsupported kwargs for cross-provider compatibility                                                                                                                                                                                                                                                          
  - Lazy `import litellm` inside `litellm_fn()` -- base install unaffected if litellm is not installed                                                                                                                                                                                                                                                                    
  - Follows the exact same pattern as `together_fn`, `openrouter_fn`, `minimax_fn`
    - LiteLLM is NOT in `unsafe_providers` -- it resolves API keys from provider-specific env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) at call time, so no LITELLM_API_KEY is required at init                                                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                          
  ## Usage
  
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                       
  ```ini 
  Anthropic Claude:                                                                                                                                                                                                                                                                                                                                                                 
  [MAIN]                                                                                                                                                                                                                                                                                                                                                                  
  is_local = False                                                                                                                                                                                                                                                                                                                                                        
  provider_name = litellm                                                                                                                                                                                                                                                                                                                                                 
  provider_model = anthropic/claude-sonnet-4-20250514                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                          
  OpenAI:                                                                                                                                                                                                                                                                                                                                                                 
  [MAIN]                                                                                                                                                                                                                                                                                                                                                                  
  is_local = False                                                                                                                                                                                                                                                                                                                                                        
  provider_name = litellm                                                                                                                                                                                                                                                                                                                                                 
  provider_model = gpt-4o                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
  Azure OpenAI:                                                                                                                                                                                                                                                                                                                                                           
  [MAIN]                                                                                                                                                                                                                                                                                                                                                                  
  is_local = False                                                                                                                                                                                                                                                                                                                                                        
  provider_name = litellm                                                                                                                                                                                                                                                                                                                                                 
  provider_model = azure/gpt-4o                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                          
  AWS Bedrock:                                                                                                                                                                                                                                                                                                                                                            
  [MAIN]                                                                                                                                                                                                                                                                                                                                                                  
  is_local = False                                                                                                                                                                                                                                                                                                                                                        
  provider_name = litellm                                                                                                                                                                                                                                                                                                                                                 
  provider_model = bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                          
  Groq (fast inference):                                                                                                                                                                                                                                                                                                                                                  
  [MAIN]                                                                                                                                                                                                                                                                                                                                                                  
  is_local = False                                                                                                                                                                                                                                                                                                                                                        
  provider_name = litellm                                                                                                                                                                                                                                                                                                                                                 
  provider_model = groq/llama-3.3-70b-versatile                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                          
  Ollama (local, via litellm routing):                                                                                                                                                                                                                                                                                                                                    
  [MAIN]                                                                                                                                                                                                                                                                                                                                                                  
  is_local = False                                                                                                                                                                                                                                                                                                                                                        
  provider_name = litellm                                                                                                                                                                                                                                                                                                                                                 
  provider_model = ollama/llama3                                                                                                                                                                                                                                                                                                                                          
 ```
                                                                                                                                                                                                                                                                                                                                                                          
  Set the API key as env var: export LITELLM_API_KEY=sk-... or LiteLLM auto-resolves from provider-specific vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, GROQ_API_KEY, etc.).                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
  100+ more providers at https://docs.litellm.ai/docs/providers                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                          
  Unit tests (9/9 pass):                                                                                                                                                                                                                                                                                                                                                  
```                                                                                                                                                                                                                                                                                                                                                                          
  test_litellm_provider_registered PASSED                                                                                                                                                                                                                                                                                                                                 
  test_litellm_not_in_unsafe_providers PASSED                                                                                                                                                                                                                                                                                                                             
  test_litellm_no_api_key_required_at_init PASSED                                                                                                                                                                                                                                                                                                                         
  test_litellm_local_not_supported PASSED                                                                                                                                                                                                                                                                                                                               
  test_litellm_fn_returns_content PASSED                                                                                                                                                                                                                                                                                                                                  
  test_litellm_fn_passes_drop_params PASSED
  test_litellm_fn_passes_model PASSED                                                                                                                                                                                                                                                                                                                                     
  test_litellm_fn_passes_api_key_from_env PASSED                                                                                                                                                                                                                                                                                                                        
  test_litellm_fn_omits_api_key_when_not_set PASSED                                                                                                                                                                                                                                                                                                                       
  test_litellm_fn_raises_on_empty_response PASSED                                                                                                                                                                                                                                                                                                                         
  test_litellm_fn_raises_on_api_error PASSED     
  ============================== 11 passed in 1.23s ==============================                                                                                                                                                                                                                                                                                        
```
                                                                                                                                                                                                                                                                                                                                                                          
E2E against Anthropic Claude Sonnet 4-6 (via Azure):                                                                                                                                                                                                                                                                                                               

```                                                                                                                                                                                                                                                                                                                                                                          
  ================================================================                                                                                                                                                                                                                                                                                                        
    agenticSeek LiteLLM Provider -- Full E2E Integration Tests
  ================================================================                                                                                                                                                                                                                                                                                                        
   
  [Test 1] Provider initialization                                                                                                                                                                                                                                                                                                                                        
    Provider: litellm                     
    Model: anthropic/claude-sonnet-4-6
    Registered: True
    Unsafe (cloud): False
    PASSED

  [Test 2] Single-turn text generation (litellm_fn)                                                                                                                                                                                                                                                                                                                       
    Prompt: What is the capital of France? Reply in one word.
    Response: Paris                                                                                                                                                                                                                                                                                                                                                       
    PASSED                                

  [Test 3] Multi-turn conversation (litellm_fn)
    System: You are a helpful math tutor. Be concise.
    User: What is 15 * 3?                                                                                                                                                                                                                                                                                                                                                 
    Assistant: 45
    User: Now divide that by 9.                                                                                                                                                                                                                                                                                                                                           
    Response: 5                           
    PASSED

  [Test 4] End-to-end via respond() dispatch                                                                                                                                                                                                                                                                                                                              
    Prompt: Say hello in exactly 3 words.
    Response: Hello there, friend!                                                                                                                                                                                                                                                                                                                                        
    PASSED                                

  [Test 5] Error handling verified (covered by unit tests)
    - Empty response raises Exception
    - API errors wrapped as 'LiteLLM API error: ...'
    PASSED                                                                                                                                                                                                                                                                                                                                                                
   
  ================================================================                                                                                                                                                                                                                                                                                                        
    All 5 tests passed -- LiteLLM provider works end-to-end
  ================================================================
  ```