### PR TITLE
fix: add missing parentheses to get_status_message() call in /latest endpoint

### DIFF
--- a/api.py
+++ b/api.py
@@ -186,7 +186,7 @@ async def get_latest_answer():
             "agent_name": interaction.current_agent.agent_name if interaction.current_agent else "None",
             "success": interaction.current_agent.success,
             "blocks": {f'{i}': block.jsonify() for i, block in enumerate(interaction.get_last_blocks_result())} if interaction.current_agent else {},
-            "status": interaction.current_agent.get_status_message if interaction.current_agent else "No status available",
+            "status": interaction.current_agent.get_status_message() if interaction.current_agent else "No status available",
             "uid": uid
         }
         interaction.current_agent.last_answer = ""


### PR DESCRIPTION
Closes #496

## Problem

`get_status_message` is a method, not a property. Without `()` the response `status` field receives a bound-method object instead of a string, causing JSON serialisation to either raise a `TypeError` or embed the method's `repr` string.

## Fix

Add the missing call parentheses: `get_status_message()`.