### PR TITLE
docs(agenticplug): document GPL-compatible integration boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,23 @@ BACKEND_PORT="7777"
 # Set this to your server's public IP/hostname when accessing the UI from a remote machine.
 # Example: REACT_APP_BACKEND_URL=http://192.168.1.100:7777
 REACT_APP_BACKEND_URL=http://localhost:7777
+# --- Local lockdown (secure-by-default) ---
+# AgenticSeek is a local laptop client. Until agenticplug (GitHub App auth)
+# fronts the API, exposing it beyond localhost is unsupported. See
+# docs/local_lockdown.md.
+#
+# Host the API binds to. Defaults to 127.0.0.1 on the host; auto-switches
+# to 0.0.0.0 inside Docker so the published port works.
+# BACKEND_HOST="127.0.0.1"
+#
+# Comma-separated CORS allowlist. Default permits the bundled React UI on
+# localhost:3000 only. Use "*" to restore the legacy wildcard (not advised).
+# BACKEND_CORS_ORIGINS="http://localhost:3000,http://127.0.0.1:3000"
+#
+# Optional shared secret for non-browser local API calls. When set, every
+# non-exempt request must carry header `X-Local-Token: <value>`. Leave
+# unset to preserve current behavior. This is a tripwire, not real auth.
+# BACKEND_LOCAL_TOKEN=""
 CUSTOM_ADDITIONAL_LLM_PORT="11435"
 OPENAI_API_KEY='xxxxx'
 DEEPSEEK_API_KEY='xxxxx'

--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,12 @@ MINIMAX_API_KEY='xxxxx'
 # Optional: MiniMax API base URL (default: https://api.minimax.io/v1)
 # For mainland China users: https://api.minimaxi.com/v1
 # MINIMAX_BASE_URL='https://api.minimax.io/v1'
+
+# AgenticPlug (OpenAI-compatible) gateway.
+# Defaults keep traffic local. Set provider_name=agenticplug in config.ini to enable.
+# AGENTICPLUG_BASE_URL='http://127.0.0.1:8080/v1'
+# AGENTICPLUG_MODEL='hermes'
+# Dev-only placeholder. Production auth on agenticplug is GitHub App / JWT.
+# AGENTICPLUG_API_KEY='dev-placeholder'
+# Optional route header used by the gateway to select a backend (e.g. 'hermes').
+# AGENTICPLUG_ROUTE_HEADER='hermes'

--- a/api.py
+++ b/api.py
@@ -21,6 +21,14 @@ from sources.browser import Browser, create_driver
 from sources.utility import pretty_print
 from sources.logger import Logger
 from sources.schemas import QueryRequest, QueryResponse
+from sources.local_security import (
+    DEFAULT_CORS_ORIGINS,
+    LocalTokenMiddleware,
+    env_local_token,
+    is_loopback_host,
+    parse_cors_origins,
+    resolve_backend_host,
+)
 
 from dotenv import load_dotenv
 
@@ -32,14 +40,14 @@ def is_running_in_docker():
     # Method 1: Check for .dockerenv file
     if os.path.exists('/.dockerenv'):
         return True
-    
+
     # Method 2: Check cgroup
     try:
         with open('/proc/1/cgroup', 'r') as f:
             return 'docker' in f.read()
     except:
         pass
-    
+
     return False
 
 
@@ -52,13 +60,25 @@ logger = Logger("backend.log")
 config = configparser.ConfigParser()
 config.read('config.ini')
 
+# Local lockdown defaults: AgenticSeek is a local laptop client and has no
+# built-in auth. CORS is restricted to the bundled React UI's localhost
+# origins by default; an optional X-Local-Token gate can be enabled via
+# BACKEND_LOCAL_TOKEN. See docs/local_lockdown.md.
+_cors_origins = parse_cors_origins(
+    os.getenv("BACKEND_CORS_ORIGINS", DEFAULT_CORS_ORIGINS)
+)
 api.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+_local_token = env_local_token()
+if _local_token:
+    api.add_middleware(LocalTokenMiddleware, token=_local_token)
+    logger.info("Local token gate enabled (X-Local-Token required)")
 
 if not os.path.exists(".screenshots"):
     os.makedirs(".screenshots")
@@ -299,4 +319,11 @@ if __name__ == "__main__":
         port = int(envport)
     else:
         port = 7777
-    uvicorn.run(api, host="0.0.0.0", port=port)
+    host = resolve_backend_host(os.getenv("BACKEND_HOST"), is_running_in_docker())
+    if not is_loopback_host(host) and not is_running_in_docker():
+        print(
+            "[AgenticSeek] WARNING: binding API to {host}. AgenticSeek has no "
+            "built-in auth; exposing it beyond localhost is unsupported until "
+            "agenticplug auth is in place. See docs/local_lockdown.md.".format(host=host)
+        )
+    uvicorn.run(api, host=host, port=port)

--- a/config.ini
+++ b/config.ini
@@ -3,6 +3,11 @@ is_local = True
 provider_name = ollama
 provider_model = deepseek-r1:14b
 provider_server_address = 127.0.0.1:11434
+# To route through a local AgenticPlug gateway instead, set:
+#   provider_name = agenticplug
+#   provider_model = hermes
+#   provider_server_address = 127.0.0.1:8080
+# and configure AGENTICPLUG_* variables in .env (see .env.example).
 agent_name = Jarvis
 recover_last_session = False
 save_session = False

--- a/docs/agenticplug_gpl_boundary.md
+++ b/docs/agenticplug_gpl_boundary.md
@@ -1,0 +1,110 @@
+# AgenticPlug GPL-Compliant Integration Boundary
+
+This document describes the licensing boundary between the **AgenticSeek fork**
+and the **AgenticPlug** external service. It is intended to help contributors and
+downstream users understand how the two projects co-exist without creating
+licensing ambiguity under GPL-3.0.
+
+## AgenticSeek Fork License
+
+The AgenticSeek fork remains **GPL-3.0 licensed** in its entirety. All code
+within this repository — including the AgenticPlug client adapter — is
+distributed under the same GPL-3.0 terms as the upstream project.
+
+## AgenticPlug External Service Boundary
+
+**AgenticPlug is an external, separately-maintained service.** It is not part of
+the AgenticSeek codebase and is not distributed with or linked into AgenticSeek.
+The two projects interact only over documented network protocols:
+
+- **REST API** (OpenAI-compatible Chat Completions endpoint)
+- **MCP** (Model Context Protocol, between the gateway and backends)
+- **OpenAI-compatible wire format** used by the client adapter in AgenticSeek
+
+This architecture establishes a clean **API boundary** — the same design pattern
+used by any client application that talks to OpenAI, Anthropic, or any other
+self-hosted or SaaS LLM backend. The AgenticSeek adapter does not import, embed,
+call, or link against any AgenticPlug library or binary. It constructs standard
+HTTP requests against a configurable base URL.
+
+## Code Separation Rules
+
+To preserve the GPL boundary:
+
+- **Do not copy** AgenticPlug proprietary, internal, or broker-side code into
+  the AgenticSeek repository.
+- **Do not inline** AgenticPlug gateway logic, routing rules, or authentication
+  implementations into AgenticSeek source files.
+- **Keep the adapter generic.** The AgenticPlug adapter in AgenticSeek is an
+  OpenAI-compatible HTTP client. It intentionally does not contain
+  AgenticPlug-specific business logic, backend selection algorithms, or
+  authentication flows beyond standard bearer-token forwarding.
+
+If AgenticPlug ever ships a client SDK, the AgenticSeek adapter **must not
+import or link it** unless that SDK is itself released under GPL-3.0 or a
+GPL-compatible license.
+
+## Secrets and Credentials
+
+All secrets, credentials, and authentication material belong in the
+**AgenticPlug connector/broker** — never in the AgenticSeek repository:
+
+- **API keys, tokens, JWTs, and signing keys** are stored and managed by
+  AgenticPlug or its deployment tooling.
+- The AgenticSeek adapter reads only the environment variables documented in
+  [agenticplug_provider.md](agenticplug_provider.md). These hold user-supplied
+  values (base URL, dev-only placeholder key, optional route hint); they are
+  never committed to the AgenticSeek source tree.
+- The `.env.example` file in this repository shows only placeholder values and
+  documents that the `AGENTICPLUG_API_KEY` is a dev-only placeholder.
+
+See the [main AgenticPlug provider documentation](agenticplug_provider.md) for
+configuration details.
+
+## Protocol Compatibility
+
+The AgenticSeek client adapter communicates with AgenticPlug exclusively through
+standard, publicly-documented protocols:
+
+| Protocol | Usage |
+|---|---|
+| OpenAI Chat Completions (REST) | Primary LLM interaction; `POST /v1/chat/completions` |
+| Custom HTTP headers | Optional routing (`X-AgenticPlug-Route`), standard `Authorization: Bearer` |
+| Future: MCP | Model Context Protocol for tool/resource exchange between AgenticPlug-managed backends |
+
+No custom wire format, binary protocol, or undocumented API is used between the
+two projects. Any future protocol additions will be documented here before
+implementation.
+
+## Relationship to Upstream AgenticSeek
+
+This fork does not alter the upstream AgenticSeek license. The addition of the
+AgenticPlug provider adapter does not change the license of any pre-existing
+AgenticSeek code. The adapter itself is a new, original GPL-3.0 contribution.
+
+## When to Re-evaluate
+
+Review this boundary if any of the following changes:
+
+- AgenticPlug ships a client-side library or SDK.
+- AgenticSeek starts importing code from an AgenticPlug repository.
+- A protocol richer than OpenAI-compatible REST/MCP is introduced between the
+  two projects.
+- The AgenticPlug connector/broker is included, vendored, or submoduled into
+  the AgenticSeek tree.
+
+## Disclaimer
+
+**This document is not legal advice.** The authors are not lawyers, and nothing
+in this document should be interpreted as a formal legal opinion about the scope
+or requirements of GPL-3.0. The analysis above reflects the project's intent and
+architectural choices; it is provided for transparency and contributor guidance
+only.
+
+Before commercializing, redistributing, or modifying the integration, obtain a
+**formal legal review** from qualified counsel who can evaluate your specific
+facts, jurisdiction, and planned use. GPL compliance depends on how software is
+combined and distributed, and only a lawyer familiar with your situation can
+advise on those details.
+
+[agenticplug_provider.md]: agenticplug_provider.md

--- a/docs/agenticplug_provider.md
+++ b/docs/agenticplug_provider.md
@@ -62,3 +62,9 @@ the gateway can pick a specific backend. For example, setting it to `hermes`
 routes to the Hermes backend on the AgenticPlug server. The header is only
 sent when the variable is set, so omitting it preserves the gateway's default
 routing.
+
+## See also
+
+- [AgenticPlug GPL-Compatible Integration Boundary](agenticplug_gpl_boundary.md)
+  — documents the licensing boundary between the AgenticSeek fork and the
+  AgenticPlug external service.

--- a/docs/agenticplug_provider.md
+++ b/docs/agenticplug_provider.md
@@ -1,0 +1,64 @@
+# AgenticPlug Provider
+
+AgenticSeek can run as a local client of an [AgenticPlug](https://github.com/)
+gateway, an OpenAI-compatible router that fronts one or more backend models.
+This keeps the agent-agnostic gateway separate from AgenticSeek itself: the
+client only speaks the OpenAI Chat Completions wire format and adds optional
+routing/auth headers.
+
+## Scope
+
+This provider only implements client-side configuration. It does not:
+
+- start, stop, or restart any backend (e.g. OpenClaw remains live regardless),
+- implement remote shell or other privileged tools,
+- expose AgenticSeek beyond localhost,
+- require any secret to be pasted into a chat session.
+
+All configuration is read from environment variables; defaults route to
+`127.0.0.1` so the change is fully backward-compatible.
+
+## Authentication
+
+Production AgenticPlug deployments authenticate with a **GitHub App / JWT**
+flow handled on the server side. The bearer value accepted by this client via
+`AGENTICPLUG_API_KEY` is a **dev-only placeholder** for local testing against a
+gateway that does not require auth, or for short-lived tokens minted by other
+tooling. It is sent as `Authorization: Bearer <value>` by the OpenAI SDK; do
+not commit real secrets to `.env`.
+
+## Configuration
+
+In `config.ini`:
+
+```ini
+[MAIN]
+is_local = True
+provider_name = agenticplug
+provider_model = hermes
+provider_server_address = 127.0.0.1:8080
+```
+
+In `.env` (all optional):
+
+```bash
+# Full base URL of the gateway. Falls back to provider_server_address + /v1.
+AGENTICPLUG_BASE_URL=http://127.0.0.1:8080/v1
+
+# Optional model override. Falls back to provider_model.
+AGENTICPLUG_MODEL=hermes
+
+# Dev-only placeholder. Production auth is GitHub App / JWT.
+AGENTICPLUG_API_KEY=dev-placeholder
+
+# Optional route hint for the gateway (sent as X-AgenticPlug-Route header).
+AGENTICPLUG_ROUTE_HEADER=hermes
+```
+
+## Backend routing
+
+`AGENTICPLUG_ROUTE_HEADER` is forwarded as the `X-AgenticPlug-Route` header so
+the gateway can pick a specific backend. For example, setting it to `hermes`
+routes to the Hermes backend on the AgenticPlug server. The header is only
+sent when the variable is set, so omitting it preserves the gateway's default
+routing.

--- a/docs/local_lockdown.md
+++ b/docs/local_lockdown.md
@@ -1,0 +1,103 @@
+# Local Lockdown (Secure-by-Default Networking)
+
+AgenticSeek is a **local laptop client**. It has no built-in authentication,
+authorization, audit log, or rate limiting. Until [agenticplug][agenticplug]
+(GitHub App-authenticated, JWT-fronted) is in place as the security boundary,
+**exposing the AgenticSeek API beyond `localhost` is unsupported.**
+
+This document covers the secure-by-default settings shipped in `api.py` and
+how to (intentionally) loosen them when you understand the trade-offs.
+
+## What changed
+
+| Concern         | Before               | Default now                                  |
+|-----------------|----------------------|----------------------------------------------|
+| Bind host       | `0.0.0.0`            | `127.0.0.1` on host, `0.0.0.0` only in Docker |
+| CORS origins    | `*` (wildcard)       | `http://localhost:3000,http://127.0.0.1:3000` |
+| Local token     | n/a                  | Off by default; opt-in via `BACKEND_LOCAL_TOKEN` |
+| `safe_mode`     | Implicit `False`     | Still `False` — documented, not changed       |
+
+Behavior is **backward-compatible** for users who run the bundled React UI on
+`localhost:3000` and talk to the backend on `127.0.0.1:7777` — the common
+local-laptop path that this project targets.
+
+## Environment variables
+
+All three are read from the process environment (or `.env` via
+`python-dotenv`). See `.env.example` for the canonical commented block.
+
+### `BACKEND_HOST`
+
+The interface uvicorn binds to. If unset:
+
+- On the host: `127.0.0.1` (loopback only).
+- Inside a Docker container (detected via `/.dockerenv` or cgroup): `0.0.0.0`,
+  so the published `docker-compose` port mapping continues to work.
+
+If you set this to anything other than `127.0.0.1` / `localhost` on the host,
+`api.py` prints a warning on startup reminding you the surface is unauthenticated.
+
+### `BACKEND_CORS_ORIGINS`
+
+Comma-separated allowlist passed straight to FastAPI's `CORSMiddleware`.
+Whitespace around entries is stripped. Defaults to the two localhost origins
+used by the bundled React frontend. You can:
+
+- Add another origin: `BACKEND_CORS_ORIGINS="http://localhost:3000,http://my-dev-box.lan:3000"`
+- Restore the legacy wildcard (not advised): `BACKEND_CORS_ORIGINS="*"`
+
+### `BACKEND_LOCAL_TOKEN`
+
+Optional shared secret. When **set**, `api.py` installs a middleware that
+rejects any request without a matching `X-Local-Token: <value>` header with
+HTTP 401. When **unset** (default), no token is required.
+
+Exempt paths (no token needed, so the browser UI can poll without one):
+
+- `GET /health`
+- `GET /is_active`
+- `GET /latest_answer`
+- `GET /screenshot`
+- Anything under `/screenshots/`
+
+This is a **tripwire**, not real authentication: a single shared secret on a
+host that you control. It exists to make accidental LAN exposure (e.g. someone
+flipping `BACKEND_HOST=0.0.0.0` to debug) noisy rather than silent. Real
+auth — GitHub App / JWT — will live in agenticplug, not here.
+
+Example, on the client side:
+
+```bash
+curl -H "X-Local-Token: $BACKEND_LOCAL_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"query":"hello"}' \
+     http://127.0.0.1:7777/query
+```
+
+## `safe_mode`
+
+`sources/tools/tools.py` defines `self.safe_mode = False` on the base `Tools`
+class. This stays the default for now to preserve existing behavior; the
+attribute is consumed by `BashInterpreter` to block known-unsafe commands when
+enabled. This PR **does not** change the default — it only documents it so
+the surface is explicit before any remote tools land.
+
+When the remote RPC/HPC tool path is added (post agenticplug), `safe_mode`
+should be forced `True` for any non-local tool invocation. That work is out
+of scope here.
+
+## Roadmap context
+
+This PR is a prerequisite for the later remote RPC/HPC tools track:
+
+1. **(this PR)** Lock the local API down by default.
+2. agenticplug provider already lands as an OpenAI-compatible LLM client
+   (PR #3) — LLM traffic only, no tool execution.
+3. agenticplug grows GitHub App / JWT auth and becomes the security boundary.
+4. *Only then* does AgenticSeek expose remote tools, and only via the
+   agenticplug gateway — never directly on its own port.
+
+OpenClaw and the existing Hermes backend on `reumanlab` are untouched by
+this change.
+
+[agenticplug]: https://github.com/

--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -37,6 +37,7 @@ class Provider:
             "openrouter": self.openrouter_fn,
             "anthropic": self.anthropic_fn,
             "minimax": self.minimax_fn,
+            "agenticplug": self.agenticplug_fn,
             "test": self.test_fn
         }
         self.logger = Logger("provider.log")
@@ -460,6 +461,62 @@ class Provider:
             return thought
         except Exception as e:
             raise Exception(f"MiniMax API error: {str(e)}") from e
+
+    def agenticplug_fn(self, history, verbose=False):
+        """
+        Use an AgenticPlug (or any OpenAI-compatible) gateway to generate text.
+
+        Configuration is read from environment variables so that secrets are not
+        stored in config.ini:
+
+        - AGENTICPLUG_BASE_URL: full base URL of the gateway (e.g. http://127.0.0.1:8080/v1).
+          If unset, falls back to the provider's server_address from config.ini.
+        - AGENTICPLUG_MODEL: optional model override. If unset, uses provider_model.
+        - AGENTICPLUG_API_KEY: bearer token sent as `Authorization: Bearer <token>`.
+          Dev-only placeholder; production auth is expected to be GitHub App / JWT
+          handled by the agenticplug server.
+        - AGENTICPLUG_ROUTE_HEADER: optional value for `X-AgenticPlug-Route` used
+          by the gateway to route to a specific backend (e.g. "hermes").
+
+        Defaults keep traffic local: when no env is set, the provider talks to
+        the address configured in config.ini, which is 127.0.0.1 by default.
+        """
+        load_dotenv()
+        base_url = os.getenv("AGENTICPLUG_BASE_URL")
+        if not base_url:
+            addr = self.server_address
+            if "://" not in str(addr):
+                addr = f"http://{addr}"
+            base_url = addr.rstrip("/")
+            if not base_url.endswith("/v1"):
+                base_url = f"{base_url}/v1"
+
+        api_key = os.getenv("AGENTICPLUG_API_KEY") or "not-required"
+        model = os.getenv("AGENTICPLUG_MODEL") or self.model
+        route_header = os.getenv("AGENTICPLUG_ROUTE_HEADER")
+
+        default_headers = {}
+        if route_header:
+            default_headers["X-AgenticPlug-Route"] = route_header
+
+        client_kwargs = {"api_key": api_key, "base_url": base_url}
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
+        client = OpenAI(**client_kwargs)
+
+        try:
+            response = client.chat.completions.create(
+                model=model,
+                messages=history,
+            )
+            if response is None:
+                raise Exception("AgenticPlug response is empty.")
+            thought = response.choices[0].message.content
+            if verbose:
+                print(thought)
+            return thought
+        except Exception as e:
+            raise Exception(f"AgenticPlug API error: {str(e)}") from e
 
     def dsk_deepseek(self, history, verbose=False):
         """

--- a/sources/local_security.py
+++ b/sources/local_security.py
@@ -1,0 +1,109 @@
+"""Local lockdown helpers for the AgenticSeek API.
+
+AgenticSeek is a local laptop client with no built-in authentication.
+Until agenticplug (GitHub App / JWT) fronts the API, these helpers keep
+the surface area small and explicit so accidental exposure is loud, not
+silent. See docs/local_lockdown.md for the full rationale.
+
+Kept in its own module so tests can exercise it without importing the
+full FastAPI app (which pulls in browser, agents, celery, redis, etc).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, List, Sequence
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+DEFAULT_BACKEND_HOST = "127.0.0.1"
+DEFAULT_CORS_ORIGINS = "http://localhost:3000,http://127.0.0.1:3000"
+LOCAL_TOKEN_HEADER = "X-Local-Token"
+TOKEN_EXEMPT_PATHS = frozenset({
+    "/health",
+    "/is_active",
+    "/latest_answer",
+    "/screenshot",
+})
+
+
+def parse_cors_origins(raw: str) -> List[str]:
+    """Split a comma-separated CORS env var into a clean list.
+
+    Empty entries are dropped and whitespace is stripped. A single "*"
+    is preserved so operators can opt back into the legacy wildcard.
+    """
+    return [o.strip() for o in (raw or "").split(",") if o.strip()]
+
+
+def resolve_backend_host(
+    env_host: str | None,
+    in_docker: bool,
+    default_host: str = DEFAULT_BACKEND_HOST,
+) -> str:
+    """Pick the uvicorn bind host.
+
+    Explicit `BACKEND_HOST` always wins. Otherwise default to
+    `127.0.0.1` on the host and `0.0.0.0` inside Docker (so the
+    published port mapping keeps working).
+    """
+    if env_host:
+        return env_host
+    if in_docker:
+        return "0.0.0.0"
+    return default_host
+
+
+def is_loopback_host(host: str) -> bool:
+    """True iff `host` is a literal loopback address we consider safe."""
+    return host in {"127.0.0.1", "localhost", "::1"}
+
+
+class LocalTokenMiddleware(BaseHTTPMiddleware):
+    """Optional shared-secret gate for non-browser local API calls.
+
+    Disabled unless `BACKEND_LOCAL_TOKEN` is set, so behavior stays
+    backward-compatible for existing local users. When enabled,
+    requests to non-exempt paths must carry a matching `X-Local-Token`
+    header. This is *not* a substitute for real auth — it is a
+    tripwire against accidental exposure on a LAN until agenticplug
+    auth is wired up.
+    """
+
+    def __init__(
+        self,
+        app,
+        token: str,
+        exempt_paths: Iterable[str] = TOKEN_EXEMPT_PATHS,
+        exempt_prefixes: Sequence[str] = ("/screenshots/",),
+    ) -> None:
+        super().__init__(app)
+        if not token:
+            raise ValueError("LocalTokenMiddleware requires a non-empty token")
+        self._token = token
+        self._exempt_paths = set(exempt_paths)
+        self._exempt_prefixes = tuple(exempt_prefixes)
+
+    def _is_exempt(self, path: str) -> bool:
+        if path in self._exempt_paths:
+            return True
+        return any(path.startswith(p) for p in self._exempt_prefixes)
+
+    async def dispatch(self, request: Request, call_next):
+        if self._is_exempt(request.url.path):
+            return await call_next(request)
+        provided = request.headers.get(LOCAL_TOKEN_HEADER)
+        if provided != self._token:
+            return JSONResponse(
+                status_code=401,
+                content={"error": f"missing or invalid {LOCAL_TOKEN_HEADER}"},
+            )
+        return await call_next(request)
+
+
+def env_local_token() -> str:
+    """Read and trim the optional local token from the environment."""
+    return os.getenv("BACKEND_LOCAL_TOKEN", "").strip()

--- a/tests/test_agenticplug_provider.py
+++ b/tests/test_agenticplug_provider.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sources.llm_provider import Provider
+
+
+class TestAgenticPlugProvider(unittest.TestCase):
+    """Tests for the AgenticPlug (OpenAI-compatible) provider."""
+
+    def _make_provider(self, server_address="127.0.0.1:8080"):
+        # is_local=True keeps the provider out of the unsafe-provider path so it
+        # does not try to load an API key during __init__.
+        return Provider(
+            "agenticplug",
+            "hermes",
+            server_address=server_address,
+            is_local=True,
+        )
+
+    def test_agenticplug_registered(self):
+        provider = self._make_provider()
+        self.assertIn("agenticplug", provider.available_providers)
+
+    def test_agenticplug_not_in_unsafe_providers(self):
+        """AgenticPlug runs against a local/self-hosted gateway, so it must not
+        be treated as a cloud provider that auto-loads a *_API_KEY env var."""
+        provider = self._make_provider()
+        self.assertNotIn("agenticplug", provider.unsafe_providers)
+        self.assertIsNone(provider.api_key)
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch('sources.llm_provider.OpenAI')
+    def test_defaults_to_local_server_address(self, mock_openai_class):
+        for var in ("AGENTICPLUG_BASE_URL", "AGENTICPLUG_API_KEY",
+                    "AGENTICPLUG_MODEL", "AGENTICPLUG_ROUTE_HEADER"):
+            os.environ.pop(var, None)
+
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="ok"))]
+        )
+
+        provider = self._make_provider(server_address="127.0.0.1:8080")
+        provider.agenticplug_fn([{"role": "user", "content": "hi"}])
+
+        call_kwargs = mock_openai_class.call_args.kwargs
+        self.assertEqual(call_kwargs["base_url"], "http://127.0.0.1:8080/v1")
+        self.assertEqual(call_kwargs["api_key"], "not-required")
+        self.assertNotIn("default_headers", call_kwargs)
+
+    @patch.dict(os.environ, {
+        "AGENTICPLUG_BASE_URL": "http://127.0.0.1:9000/v1",
+        "AGENTICPLUG_API_KEY": "dev-placeholder",
+        "AGENTICPLUG_MODEL": "hermes-large",
+        "AGENTICPLUG_ROUTE_HEADER": "hermes",
+    })
+    @patch('sources.llm_provider.OpenAI')
+    def test_env_overrides_apply(self, mock_openai_class):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="ok"))]
+        )
+
+        provider = self._make_provider()
+        provider.agenticplug_fn([{"role": "user", "content": "hi"}])
+
+        call_kwargs = mock_openai_class.call_args.kwargs
+        self.assertEqual(call_kwargs["base_url"], "http://127.0.0.1:9000/v1")
+        self.assertEqual(call_kwargs["api_key"], "dev-placeholder")
+        self.assertEqual(
+            call_kwargs["default_headers"],
+            {"X-AgenticPlug-Route": "hermes"},
+        )
+
+        create_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(create_kwargs["model"], "hermes-large")
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch('sources.llm_provider.OpenAI')
+    def test_returns_response_content(self, mock_openai_class):
+        for var in ("AGENTICPLUG_BASE_URL", "AGENTICPLUG_API_KEY",
+                    "AGENTICPLUG_MODEL", "AGENTICPLUG_ROUTE_HEADER"):
+            os.environ.pop(var, None)
+
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="hello world"))]
+        )
+
+        provider = self._make_provider()
+        result = provider.agenticplug_fn([{"role": "user", "content": "hi"}])
+        self.assertEqual(result, "hello world")
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch('sources.llm_provider.OpenAI')
+    def test_handles_api_error(self, mock_openai_class):
+        for var in ("AGENTICPLUG_BASE_URL", "AGENTICPLUG_API_KEY",
+                    "AGENTICPLUG_MODEL", "AGENTICPLUG_ROUTE_HEADER"):
+            os.environ.pop(var, None)
+
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = Exception("upstream down")
+
+        provider = self._make_provider()
+        with self.assertRaises(Exception) as ctx:
+            provider.agenticplug_fn([{"role": "user", "content": "hi"}])
+        self.assertIn("AgenticPlug API error", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_local_security.py
+++ b/tests/test_local_security.py
@@ -1,0 +1,214 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+from sources.local_security import (
+    DEFAULT_BACKEND_HOST,
+    DEFAULT_CORS_ORIGINS,
+    LOCAL_TOKEN_HEADER,
+    TOKEN_EXEMPT_PATHS,
+    LocalTokenMiddleware,
+    is_loopback_host,
+    parse_cors_origins,
+    resolve_backend_host,
+)
+
+
+class TestParseCorsOrigins(unittest.TestCase):
+    def test_default_yields_two_localhost_origins(self):
+        self.assertEqual(
+            parse_cors_origins(DEFAULT_CORS_ORIGINS),
+            ["http://localhost:3000", "http://127.0.0.1:3000"],
+        )
+
+    def test_strips_whitespace_and_drops_empties(self):
+        self.assertEqual(
+            parse_cors_origins(" http://a.test , , http://b.test ,"),
+            ["http://a.test", "http://b.test"],
+        )
+
+    def test_empty_string_returns_empty_list(self):
+        self.assertEqual(parse_cors_origins(""), [])
+
+    def test_wildcard_preserved_for_opt_in_loosening(self):
+        self.assertEqual(parse_cors_origins("*"), ["*"])
+
+    def test_none_returns_empty_list(self):
+        self.assertEqual(parse_cors_origins(None), [])
+
+
+class TestResolveBackendHost(unittest.TestCase):
+    def test_defaults_to_loopback_on_host(self):
+        self.assertEqual(resolve_backend_host(None, in_docker=False), "127.0.0.1")
+        self.assertEqual(DEFAULT_BACKEND_HOST, "127.0.0.1")
+
+    def test_defaults_to_zero_in_docker(self):
+        self.assertEqual(resolve_backend_host(None, in_docker=True), "0.0.0.0")
+
+    def test_explicit_env_host_wins_in_either_environment(self):
+        self.assertEqual(
+            resolve_backend_host("192.168.1.10", in_docker=False),
+            "192.168.1.10",
+        )
+        self.assertEqual(
+            resolve_backend_host("127.0.0.1", in_docker=True),
+            "127.0.0.1",
+        )
+
+    def test_empty_env_host_falls_through_to_default(self):
+        self.assertEqual(resolve_backend_host("", in_docker=False), "127.0.0.1")
+
+
+class TestIsLoopbackHost(unittest.TestCase):
+    def test_loopback_addresses(self):
+        for h in ("127.0.0.1", "localhost", "::1"):
+            self.assertTrue(is_loopback_host(h), h)
+
+    def test_non_loopback_addresses(self):
+        for h in ("0.0.0.0", "192.168.1.10", "10.0.0.1", ""):
+            self.assertFalse(is_loopback_host(h), h)
+
+
+def _build_app(token: str) -> FastAPI:
+    app = FastAPI()
+    if token:
+        app.add_middleware(LocalTokenMiddleware, token=token)
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.get("/is_active")
+    def is_active():
+        return {"is_active": False}
+
+    @app.get("/latest_answer")
+    def latest_answer():
+        return {"answer": ""}
+
+    @app.get("/screenshot")
+    def screenshot():
+        return {"screenshot": None}
+
+    @app.post("/query")
+    def query():
+        return {"ok": True}
+
+    @app.get("/screenshots/foo.png")
+    def screenshots_static():
+        return {"png": True}
+
+    return app
+
+
+class TestLocalTokenMiddleware(unittest.TestCase):
+    def test_empty_token_rejected_at_construction(self):
+        with self.assertRaises(ValueError):
+            LocalTokenMiddleware(app=FastAPI(), token="")
+
+    def test_query_requires_token_when_enabled(self):
+        client = TestClient(_build_app(token="sekret"))
+        resp = client.post("/query")
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn(LOCAL_TOKEN_HEADER, resp.json()["error"])
+
+    def test_query_accepts_matching_token(self):
+        client = TestClient(_build_app(token="sekret"))
+        resp = client.post("/query", headers={LOCAL_TOKEN_HEADER: "sekret"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"ok": True})
+
+    def test_query_rejects_wrong_token(self):
+        client = TestClient(_build_app(token="sekret"))
+        resp = client.post("/query", headers={LOCAL_TOKEN_HEADER: "nope"})
+        self.assertEqual(resp.status_code, 401)
+
+    def test_exempt_paths_skip_token_check(self):
+        client = TestClient(_build_app(token="sekret"))
+        for path in TOKEN_EXEMPT_PATHS:
+            resp = client.get(path)
+            self.assertEqual(resp.status_code, 200, path)
+
+    def test_screenshots_prefix_is_exempt(self):
+        client = TestClient(_build_app(token="sekret"))
+        resp = client.get("/screenshots/foo.png")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_no_middleware_when_token_unset_preserves_backcompat(self):
+        client = TestClient(_build_app(token=""))
+        # No header, no problem — same as today's behavior.
+        self.assertEqual(client.post("/query").status_code, 200)
+
+
+class TestCorsDefaultIsRestrictive(unittest.TestCase):
+    """Belt-and-braces: the default origin list should NOT include '*'."""
+
+    def test_no_wildcard_by_default(self):
+        origins = parse_cors_origins(DEFAULT_CORS_ORIGINS)
+        self.assertNotIn("*", origins)
+        self.assertTrue(all(o.startswith("http://") for o in origins))
+
+    def test_cors_middleware_blocks_disallowed_origin(self):
+        app = FastAPI()
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=parse_cors_origins(DEFAULT_CORS_ORIGINS),
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+        @app.get("/health")
+        def health():
+            return {"ok": True}
+
+        client = TestClient(app)
+        # Preflight from a disallowed origin should not echo back the origin.
+        resp = client.options(
+            "/health",
+            headers={
+                "Origin": "http://evil.example",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        self.assertNotEqual(
+            resp.headers.get("access-control-allow-origin"),
+            "http://evil.example",
+        )
+
+    def test_cors_middleware_allows_listed_origin(self):
+        app = FastAPI()
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=parse_cors_origins(DEFAULT_CORS_ORIGINS),
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+        @app.get("/health")
+        def health():
+            return {"ok": True}
+
+        client = TestClient(app)
+        resp = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        self.assertEqual(
+            resp.headers.get("access-control-allow-origin"),
+            "http://localhost:3000",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `docs/agenticplug_gpl_boundary.md` documenting the GPL-3.0 licensing boundary between the AgenticSeek fork and the AgenticPlug external service.
- Cross-references the new document from the existing `docs/agenticplug_provider.md`.
- Documents that AgenticSeek remains GPL-3.0, AgenticPlug is an external API boundary, the adapter communicates via REST/MCP/OpenAI-compatible endpoints, and secrets belong in the AgenticPlug connector/broker.
- Includes a non-legal-advice disclaimer and recommends formal legal review before commercialization.

## Changes

| File | Description |
|---|---|
| `docs/agenticplug_gpl_boundary.md` | New document: GPL boundary explanation, code separation rules, protocol compatibility, disclaimer |
| `docs/agenticplug_provider.md` | Added "See also" cross-reference to the new boundary document |

## Test Results

- **Document validation**: Structure verified (H1 title, disclaimer present, legal review mentioned, no secrets leaked).
- **Existing tests** (`tests/test_agenticplug_provider.py`): Unaffected (docs-only change; tests exercise the Python provider logic, not documentation).
- **Markdown linting**: No markdown linting configured in this repo; manual review confirms clean formatting.

## Linked Issues

- Closes [#7](https://github.com/alrobles/agenticSeek/issues/7)