### PR TITLE
fix: add missing parentheses on get_status_message() call

### DIFF
--- a/api.py
+++ b/api.py
@@ -187,7 +187,7 @@ async def get_latest_answer():
             "agent_name": interaction.current_agent.agent_name if interaction.current_agent else "None",
             "success": interaction.current_agent.success,
             "blocks": {f'{i}': block.jsonify() for i, block in enumerate(interaction.get_last_blocks_result())} if interaction.current_agent else {},
-            "status": interaction.current_agent.get_status_message if interaction.current_agent else "No status available",
+            "status": interaction.current_agent.get_status_message() if interaction.current_agent else "No status available",
             "uid": uid
         }
         interaction.current_agent.last_answer = ""


### PR DESCRIPTION
## Problem

In  line 190, the  endpoint returns:

```python
"status": interaction.current_agent.get_status_message if interaction.current_agent else "No status available",
```

`get_status_message` is a method (defined in `sources/agents/agent.py:78`), not a property. Without call parentheses `()`, the response serialises a bound-method object instead of the actual status string, producing something like `"<bound method Agent.get_status_message of ...>"`.

## Fix

Added `()` to call the method:

```python
"status": interaction.current_agent.get_status_message() if interaction.current_agent else "No status available",
```

Fixes #496