### PR TITLE
Harden default network exposure of the unauthenticated backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,14 @@ WORK_DIR="/Users/username/Documents/workspace_with_my_files"
 OLLAMA_PORT="11434"
 LM_STUDIO_PORT="1234"
 BACKEND_PORT="7777"
+# Network interface the backend binds to. Defaults to 127.0.0.1 (loopback only).
+# The /query endpoint is UNAUTHENTICATED and the agent runs shell commands on the
+# host, so binding to a network interface is equivalent to exposing remote code
+# execution. Only set this to 0.0.0.0 on a trusted network and behind an
+# authenticating reverse proxy or firewall.
+BACKEND_HOST="127.0.0.1"
+# Comma-separated list of browser origins allowed to call the backend (CORS).
+FRONTEND_ORIGINS="http://localhost:3000"
 # Set this to your server's public IP/hostname when accessing the UI from a remote machine.
 # Example: REACT_APP_BACKEND_URL=http://192.168.1.100:7777
 REACT_APP_BACKEND_URL=http://localhost:7777

--- a/api.py
+++ b/api.py
@@ -53,9 +53,15 @@ logger = Logger("backend.log")
 config = configparser.ConfigParser()
 config.read('config.ini')
 
+allowed_origins = [
+    origin.strip()
+    for origin in os.getenv("FRONTEND_ORIGINS", "http://localhost:3000").split(",")
+    if origin.strip()
+]
+
 api.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -301,4 +307,16 @@ if __name__ == "__main__":
         port = int(envport)
     else:
         port = 7777
-    uvicorn.run(api, host="0.0.0.0", port=port)
+    # Bind to loopback by default. The /query endpoint is unauthenticated and the
+    # coder agent executes shell commands on the host, so exposing it on a network
+    # interface is equivalent to handing out remote code execution. Set BACKEND_HOST
+    # explicitly (and put the service behind authentication / a firewall) to expose it.
+    host = os.getenv("BACKEND_HOST", "127.0.0.1")
+    if host not in ("127.0.0.1", "localhost", "::1"):
+        pretty_print(
+            f"SECURITY WARNING: backend bound to {host}. The API is unauthenticated and "
+            "can execute shell commands on this host. Only do this on a trusted network "
+            "and behind an authenticating reverse proxy or firewall.",
+            color="failure",
+        )
+    uvicorn.run(api, host=host, port=port)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,11 @@ services:
       context: .
       dockerfile: Dockerfile.backend
     ports:
-      - ${BACKEND_PORT:-7777}:${BACKEND_PORT:-7777}
+      # Publish on the host loopback only. The backend is unauthenticated and the
+      # agent runs shell commands on the host, so it must not be reachable from the
+      # network by default. To expose it intentionally, change this to
+      # "0.0.0.0:${BACKEND_PORT}:${BACKEND_PORT}" and put it behind auth/a firewall.
+      - 127.0.0.1:${BACKEND_PORT:-7777}:${BACKEND_PORT:-7777}
     volumes:
       - ./:/app
       - ${WORK_DIR:-.}:/opt/workspace
@@ -85,6 +89,11 @@ services:
       - REDIS_URL=${REDIS_BASE_URL:-redis://redis:6379/0}
       - WORK_DIR=/opt/workspace
       - BACKEND_PORT=${BACKEND_PORT}
+      # Bind 0.0.0.0 *inside* the container so the loopback-only published port
+      # (see the "ports" mapping above) can reach it. The host only exposes the
+      # port on 127.0.0.1, so it is not reachable from the network by default.
+      - BACKEND_HOST=0.0.0.0
+      - FRONTEND_ORIGINS=${FRONTEND_ORIGINS:-http://localhost:3000}
       - DOCKER_INTERNAL_URL=http://host.docker.internal
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}


### PR DESCRIPTION
## Summary

The backend serves an **unauthenticated** `POST /query` endpoint whose coder agent is designed to execute shell commands on the host (`subprocess.Popen(..., shell=True)`). By default the server binds to `0.0.0.0` and the docker-compose mapping publishes the port on all host interfaces, with CORS set to `allow_origins=["*"]`. The result is that, out of the box, any host on the same network (or the internet, if the service is exposed per the project's own remote-deployment guidance) can reach the endpoint and drive the agent into running arbitrary commands — effectively unauthenticated remote code execution.

The agent's ability to run code is intentional; the problem is that this capability is exposed on a network interface with no authentication. This PR makes the default deployment **loopback-only and secure-by-default**, while leaving an explicit, well-documented opt-in for users who genuinely want to expose it.

## Changes

- **Bind to loopback by default.** `api.py` now reads `BACKEND_HOST` (default `127.0.0.1`) instead of hardcoding `0.0.0.0`. When bound to a non-loopback interface, a prominent startup security warning is printed.
- **Loopback-only port publishing in Docker.** `docker-compose.yml` publishes the backend port on `127.0.0.1` only. The container still binds `0.0.0.0` internally (via `BACKEND_HOST=0.0.0.0` in the service env) so the published loopback port works; the host does not expose it to the network.
- **CORS allow-list.** CORS is restricted to a configurable `FRONTEND_ORIGINS` list (default `http://localhost:3000`) instead of `*`.
- **Documentation.** `.env.example` documents `BACKEND_HOST` and `FRONTEND_ORIGINS`, including a clear warning that exposing the backend is equivalent to exposing remote code execution.

## Impact / Compatibility

- **Local host install (`python3 api.py`):** browser on the same machine reaches `127.0.0.1:7777` as before — no change in experience, now not reachable from the LAN.
- **Docker (`./start_services.sh full`):** the browser on the host reaches the loopback-published port as before — unchanged.
- **Remote / server deployment:** users now consciously opt in by setting `BACKEND_HOST=0.0.0.0` (host install) or changing the compose mapping to `0.0.0.0:...`, and are warned to place the service behind authentication / a firewall.

## How to verify

```bash
# Host install: backend is no longer reachable on a non-loopback address by default
python3 api.py            # binds 127.0.0.1:7777
curl http://127.0.0.1:7777/health   # works locally
# from another machine on the LAN -> connection refused

# Opt-in exposure prints a warning:
BACKEND_HOST=0.0.0.0 python3 api.py
```

## Notes

This is a defense-in-depth / secure-default change for the network-exposure surface. A follow-up adding optional API-key authentication on the request endpoints (so the service can be exposed safely behind a proxy) would be a natural complement; happy to work on that separately if you'd like.

If you agree this is worth tracking as a security fix, I would kindly ask you to consider requesting a CVE ID for it once merged, so downstream users and distributions can track and apply the change. Thank you very much for your time and for your work on this project.
