### PR TITLE
feat: add Tavily as configurable alternative to SearxNG for web search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ TOGETHER_API_KEY='xxxxx'
 GOOGLE_API_KEY='xxxxx'
 ANTHROPIC_API_KEY='xxxxx'
 MINIMAX_API_KEY='xxxxx'
+TAVILY_API_KEY='xxxxx'
 # Optional: MiniMax API base URL (default: https://api.minimax.io/v1)
 # For mainland China users: https://api.minimaxi.com/v1
 # MINIMAX_BASE_URL='https://api.minimax.io/v1'

--- a/config.ini
+++ b/config.ini
@@ -10,6 +10,7 @@ speak = False
 listen = False
 jarvis_personality = False
 languages = en
+search_provider = searxng
 [BROWSER]
 headless_browser = True
 stealth_mode = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ openai
 sniffio
 ordered_set
 pypinyin
+tavily-python
 
 # Optional: TTS support (requires Python <3.12)
 # pip install kokoro==0.9.4 soundfile ipython

--- a/sources/agents/browser_agent.py
+++ b/sources/agents/browser_agent.py
@@ -1,5 +1,6 @@
 import re
 import time
+import configparser
 from datetime import date
 from typing import List, Tuple, Type, Dict
 from enum import Enum
@@ -8,6 +9,7 @@ import asyncio
 from sources.utility import pretty_print, animate_thinking
 from sources.agents.agent import Agent
 from sources.tools.searxSearch import searxSearch
+from sources.tools.tavilySearch import tavilySearch
 from sources.browser import Browser
 from sources.logger import Logger
 from sources.memory import Memory
@@ -26,7 +28,7 @@ class BrowserAgent(Agent):
         """
         super().__init__(name, prompt_path, provider, verbose, browser)
         self.tools = {
-            "web_search": searxSearch(),
+            "web_search": self._init_search_tool(),
         }
         self.role = "web"
         self.type = "browser_agent"
@@ -43,6 +45,15 @@ class BrowserAgent(Agent):
                         memory_compression=False,
                         model_provider=provider.get_model_name() if provider else None)
     
+    def _init_search_tool(self):
+        """Select search tool based on config.ini search_provider setting."""
+        config = configparser.ConfigParser()
+        config.read('./config.ini')
+        provider = config.get('MAIN', 'search_provider', fallback='searxng').strip().lower()
+        if provider == 'tavily':
+            return tavilySearch()
+        return searxSearch()
+
     def get_today_date(self) -> str:
         """Get the date"""
         date_time = date.today()

--- a/sources/agents/casual_agent.py
+++ b/sources/agents/casual_agent.py
@@ -1,8 +1,10 @@
 import asyncio
+import configparser
 
 from sources.utility import pretty_print, animate_thinking
 from sources.agents.agent import Agent
 from sources.tools.searxSearch import searxSearch
+from sources.tools.tavilySearch import tavilySearch
 from sources.tools.flightSearch import FlightSearch
 from sources.tools.fileFinder import FileFinder
 from sources.tools.BashInterpreter import BashInterpreter

--- a/sources/tools/tavilySearch.py
+++ b/sources/tools/tavilySearch.py
@@ -1,0 +1,69 @@
+import sys
+import os
+
+if __name__ == "__main__": # if running as a script for individual testing
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from tavily import TavilyClient
+from sources.tools.tools import Tools
+
+class tavilySearch(Tools):
+    def __init__(self):
+        """
+        A tool for searching the web using the Tavily API.
+        """
+        super().__init__()
+        self.tag = "web_search"
+        self.name = "tavilySearch"
+        self.description = "A tool for searching the web using Tavily"
+        api_key = os.getenv("TAVILY_API_KEY")
+        if not api_key:
+            raise ValueError("TAVILY_API_KEY must be set as an environment variable.")
+        self.client = TavilyClient(api_key=api_key)
+
+    def execute(self, blocks: list, safety: bool = False) -> str:
+        """Executes a search query using the Tavily API and returns formatted results."""
+        if not blocks:
+            return "Error: No search query provided."
+
+        query = blocks[0].strip()
+        if not query:
+            return "Error: Empty search query provided."
+
+        try:
+            response = self.client.search(
+                query=query,
+                max_results=10,
+                search_depth="basic",
+                topic="general"
+            )
+            results = []
+            for result in response.get("results", []):
+                title = result.get("title", "No Title")
+                snippet = result.get("content", "No Description")
+                url = result.get("url", "")
+                results.append(f"Title:{title}\nSnippet:{snippet}\nLink:{url}")
+            if len(results) == 0:
+                return "No search results, web search failed."
+            return "\n\n".join(results)
+        except Exception as e:
+            return f"Error during search: Tavily search failed. ({str(e)})"
+
+    def execution_failure_check(self, output: str) -> bool:
+        """
+        Checks if the execution failed based on the output.
+        """
+        return "Error" in output or "No search results" in output
+
+    def interpreter_feedback(self, output: str) -> str:
+        """
+        Feedback of web search to agent.
+        """
+        if self.execution_failure_check(output):
+            return f"Web search failed: {output}"
+        return f"Web search result:\n{output}"
+
+if __name__ == "__main__":
+    search_tool = tavilySearch()
+    result = search_tool.execute(["are dogs better than cats?"])
+    print(result)


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable alternative search provider alongside the existing SearxNG integration. Users can switch between providers via the `search_provider` key in `config.ini` without code changes.

- **SearxNG remains the default** — no existing behavior changes
- Tavily is purely additive and activated by setting `search_provider = tavily` in `config.ini`

## Changes

### New file
- `sources/tools/tavilySearch.py` — Implements `tavilySearch` class with the same `Tools` base interface (`execute`, `execution_failure_check`, `interpreter_feedback`) wrapping the `tavily-python` SDK. Output format matches `searxSearch` (Title/Snippet/Link).

### Modified files
- `sources/agents/browser_agent.py` — Added `_init_search_tool()` method that reads `search_provider` from `config.ini` and returns either `searxSearch` or `tavilySearch`. Imports both search classes.
- `sources/agents/casual_agent.py` — Added import for `tavilySearch` alongside existing `searxSearch` import.
- `config.ini` — Added `search_provider = searxng` under `[MAIN]`.
- `.env.example` — Added `TAVILY_API_KEY='xxxxx'` placeholder.
- `requirements.txt` — Added `tavily-python` dependency.

## Dependency changes
- Added `tavily-python` to `requirements.txt`

## Environment variable changes
- Added `TAVILY_API_KEY` (required when `search_provider=tavily`)

## Notes for reviewers
- The `tavilySearch` output format intentionally mirrors `searxSearch` so `BrowserAgent.jsonify_search_results()` works unchanged.
- `CasualAgent` imports both providers but currently has an empty tools dict — the import is added for consistency with the plan.


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration for the `searxng-primary-web-search` unit is functionally correct. `tavilySearch` properly extends the `Tools` base class, uses the `tavily-python` SDK correctly, and produces output in the same format as `searxSearch` (Title/Snippet/Link). `BrowserAgent._init_search_tool()` correctly reads `search_provider` from `config.ini` with `searxng` as the default fallback. All six reported files are updated. One major issue exists: `casual_agent.py` imports both `tavilySearch` and `configparser` but never uses them — `CasualAgent` has an empty `self.tools = {}` dict with no web search capability, making these dead imports. No critical issues block approval.
