### PR TITLE
feat: document Tavily as replacement path for deprecated SerpAPI webSearch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ TOGETHER_API_KEY='xxxxx'
 GOOGLE_API_KEY='xxxxx'
 ANTHROPIC_API_KEY='xxxxx'
 MINIMAX_API_KEY='xxxxx'
+TAVILY_API_KEY='xxxxx'
 # Optional: MiniMax API base URL (default: https://api.minimax.io/v1)
 # For mainland China users: https://api.minimaxi.com/v1
 # MINIMAX_BASE_URL='https://api.minimax.io/v1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ openai
 sniffio
 ordered_set
 pypinyin
+tavily-python>=0.5.0
 
 # Optional: TTS support (requires Python <3.12)
 # pip install kokoro==0.9.4 soundfile ipython

--- a/sources/tools/__init__.py
+++ b/sources/tools/__init__.py
@@ -2,4 +2,4 @@ from .PyInterpreter import PyInterpreter
 from .BashInterpreter import BashInterpreter
 from .fileFinder import FileFinder
 
-__all__ = ["PyInterpreter", "BashInterpreter", "FileFinder", "webSearch", "FlightSearch", "GoInterpreter", "CInterpreter", "GoInterpreter"]
+__all__ = ["PyInterpreter", "BashInterpreter", "FileFinder", "webSearch", "FlightSearch", "GoInterpreter", "CInterpreter", "GoInterpreter", "tavilySearch"]

--- a/sources/tools/webSearch.py
+++ b/sources/tools/webSearch.py
@@ -11,6 +11,8 @@ from sources.utility import animate_thinking, pretty_print
 """
 WARNING
 webSearch is fully deprecated and is being replaced by searxSearch for web search.
+For a cloud-hosted alternative that does not require a self-hosted SearxNG instance,
+use tavilySearch (powered by Tavily) instead.
 """
 
 class webSearch(Tools):


### PR DESCRIPTION
## Summary

- Updated the deprecation warning in `sources/tools/webSearch.py` to reference `tavilySearch` as a cloud-hosted alternative for users who cannot run a self-hosted SearxNG instance
- Added `tavilySearch` to `__all__` exports in `sources/tools/__init__.py`
- Added `tavily-python>=0.5.0` to `requirements.txt`
- Added `TAVILY_API_KEY` to `.env.example`

## Files Changed

- `sources/tools/webSearch.py` — Updated deprecation docstring to mention tavilySearch
- `sources/tools/__init__.py` — Added tavilySearch to `__all__` exports
- `requirements.txt` — Added `tavily-python>=0.5.0` dependency
- `.env.example` — Added `TAVILY_API_KEY` placeholder

## Dependency Changes

- Added `tavily-python>=0.5.0` to `requirements.txt`

## Environment Variable Changes

- Added `TAVILY_API_KEY` to `.env.example`

## Notes for Reviewers

- This is an **additive** change — SerpAPI code and `SERPAPI_KEY` env var are kept as-is
- `webSearch.py` remains deprecated; the docstring now points users to both `searxSearch` (self-hosted) and `tavilySearch` (cloud-hosted) as replacement options
- The `tavilySearch` class itself is expected to be implemented in a separate migration unit

### Automated Review

- Passed after 1 attempt(s)
- Final review: The changes are minimal, correct, and well-scoped. The docstring update in `webSearch.py` clearly directs users to `tavilySearch` as a cloud-hosted alternative. Adding `tavilySearch` to `__all__` in `__init__.py` is consistent with the existing pattern (several other entries like `webSearch`, `FlightSearch`, `GoInterpreter` are listed without top-level imports). The only concern is that `requirements.txt` and `.env.example` modifications duplicate what the prerequisite unit (searxng-primary-web-search, PR #513) also adds — these will produce merge conflicts or duplicate entries when both PRs land on main and should be coordinated at integration time.
