### PR TITLE
feat: add Tavily web-search fallback to FlightSearch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ openai
 sniffio
 ordered_set
 pypinyin
+tavily-python>=0.5.0
 
 # Optional: TTS support (requires Python <3.12)
 # pip install kokoro==0.9.4 soundfile ipython

--- a/sources/tools/flightSearch.py
+++ b/sources/tools/flightSearch.py
@@ -1,3 +1,11 @@
+"""
+Flight search tool using SerpApi's Google Flights endpoint.
+
+Supports an optional Tavily web-search fallback when SERPAPI_API_KEY is
+absent but TAVILY_API_KEY is set.  The Tavily path returns general web
+snippets rather than structured flight records.
+"""
+
 import os, sys
 import requests
 import dotenv
@@ -13,16 +21,55 @@ class FlightSearch(Tools):
     def __init__(self, api_key: str = None):
         """
         A tool to search for flight information using a flight number via SerpApi.
+        Falls back to Tavily web search when SERPAPI_API_KEY is unset and TAVILY_API_KEY is available.
         """
         super().__init__()
         self.tag = "flight_search"
         self.name = "Flight Search"
         self.description = "Search for flight information using a flight number via SerpApi."
         self.api_key = api_key or os.getenv("SERPAPI_API_KEY")
+        self.tavily_api_key = os.getenv("TAVILY_API_KEY")
+
+    def _tavily_flight_search(self, flight_number: str) -> str:
+        """Use Tavily web search as a best-effort fallback for flight info."""
+        try:
+            from tavily import TavilyClient
+            client = TavilyClient(api_key=self.tavily_api_key)
+            response = client.search(
+                query=f"flight {flight_number} status",
+                max_results=5,
+                search_depth="basic",
+                topic="general",
+            )
+            results = response.get("results", [])
+            if not results:
+                return f"No flight information found for {flight_number}"
+            snippets = []
+            for r in results:
+                title = r.get("title", "")
+                content = r.get("content", "")
+                url = r.get("url", "")
+                snippets.append(f"- {title}\n  {content}\n  {url}")
+            return (
+                f"Flight: {flight_number} (web search results)\n\n"
+                + "\n\n".join(snippets)
+            )
+        except ImportError:
+            return "Error: tavily-python package is not installed."
+        except Exception as e:
+            return f"Error during Tavily flight search: {str(e)}"
 
     def execute(self, blocks: str, safety: bool = True) -> str:
-        if self.api_key is None:
-            return "Error: No SerpApi key provided."
+        if self.api_key is None and not self.tavily_api_key:
+            return "Error: No SerpApi or Tavily API key provided."
+
+        if self.api_key is None and self.tavily_api_key:
+            for block in blocks:
+                flight_number = block.strip().upper().replace('\n', '')
+                if not flight_number:
+                    return "Error: No flight number provided."
+                return self._tavily_flight_search(flight_number)
+            return "No flight search performed"
         
         for block in blocks:
             flight_number = block.strip().upper().replace('\n', '')


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable fallback search provider for the `FlightSearch` tool. When `SERPAPI_API_KEY` is not set but `TAVILY_API_KEY` is available, the tool falls back to Tavily web search to return general flight status snippets.

This is an **additive** change — the existing SerpAPI code path is fully preserved and remains the primary provider.

## Changes

### `sources/tools/flightSearch.py`
- Added file-level docstring documenting both providers
- Added `tavily_api_key` attribute reading `TAVILY_API_KEY` env var
- Added `_tavily_flight_search()` method using `TavilyClient.search()` for best-effort flight info
- Modified `execute()` to route to Tavily when SerpAPI key is missing but Tavily key is present
- Updated error message when neither key is available

### `requirements.txt`
- Added `tavily-python>=0.5.0`

## Environment variable changes
- `TAVILY_API_KEY` — new optional env var used as fallback when `SERPAPI_API_KEY` is absent

## Notes for reviewers
- Tavily returns web snippets, not structured flight records — this is documented in the module docstring
- The `tavily` import is deferred (inside the method) to avoid import errors when the package is not installed


### Automated Review

- Passed after 1 attempt(s)
- Final review: The migration correctly adds a Tavily fallback to FlightSearch. The implementation is functional, uses valid Tavily SDK patterns, and preserves all existing SerpAPI behavior. The only notable issue is a duplicate `tavily-python` dependency in requirements.txt — the two prerequisite units (searxng-primary-web-search and serpapi-deprecated-web-search) both already add this entry, so when all three units land, requirements.txt will contain it multiple times. This is harmless at runtime (pip tolerates duplicates) but messy. No critical or major issues block approval.
