### PR TITLE
fix: read safe_mode from config.ini instead of hardcoding it

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -10,6 +10,7 @@ speak = False
 listen = False
 jarvis_personality = False
 languages = en
+safe_mode = False
 [BROWSER]
 headless_browser = True
 stealth_mode = False

--- a/sources/tools/tools.py
+++ b/sources/tools/tools.py
@@ -41,7 +41,7 @@ class Tools():
         self.config = configparser.ConfigParser()
         self.work_dir = self.create_work_dir()
         self.executable_blocks_found = False
-        self.safe_mode = False
+        self.safe_mode = self.config.getboolean('MAIN', 'safe_mode', fallback=False)
         self.allow_language_exec_bash = False
     
     def get_work_dir(self):

--- a/tests/test_safe_mode.py
+++ b/tests/test_safe_mode.py
@@ -1,0 +1,56 @@
+import unittest
+import os
+import sys
+import tempfile
+import shutil
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sources.tools.tools import Tools
+
+
+class _SafeModeTool(Tools):
+    def execute(self, blocks, safety=False):
+        return "test execution"
+
+    def execution_failure_check(self, output):
+        return False
+
+    def interpreter_feedback(self, output):
+        return "test feedback"
+
+
+class TestSafeMode(unittest.TestCase):
+    """safe_mode must be read from config.ini so the BashInterpreter unsafe-command
+    check can be enabled. Before this fix it was hardcoded False and unreachable."""
+
+    def setUp(self):
+        self._cwd = os.getcwd()
+        self._dir = tempfile.mkdtemp()
+        os.chdir(self._dir)
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+    def _write_config(self, safe_mode_line):
+        with open(os.path.join(self._dir, "config.ini"), "w") as f:
+            f.write("[MAIN]\n")
+            f.write("work_dir = {}\n".format(self._dir))
+            f.write(safe_mode_line)
+
+    def test_safe_mode_enabled_when_configured_true(self):
+        self._write_config("safe_mode = True\n")
+        self.assertTrue(_SafeModeTool().safe_mode)
+
+    def test_safe_mode_disabled_when_configured_false(self):
+        self._write_config("safe_mode = False\n")
+        self.assertFalse(_SafeModeTool().safe_mode)
+
+    def test_safe_mode_defaults_false_when_key_absent(self):
+        self._write_config("")
+        self.assertFalse(_SafeModeTool().safe_mode)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`safe_mode` is hardcoded to `False` in the `Tools` base class constructor (`sources/tools/tools.py:44`), so the unsafe-command guard in `BashInterpreter` is unreachable. The guard at `sources/tools/BashInterpreter.py:46` only blocks dangerous shell commands when `self.safe_mode` is true:

```python
if self.safe_mode and is_any_unsafe(commands):
```

Since `safe_mode` can never become `True`, that branch never runs. The `config.ini` key exists but nothing reads it.

## Solution

Read `safe_mode` from the `[MAIN]` section of `config.ini` instead of hardcoding it:

```python
self.safe_mode = self.config.getboolean('MAIN', 'safe_mode', fallback=False)
```

`create_work_dir()` already loads `config.ini` into `self.config` earlier in `__init__`, so the value is available. `getboolean(..., fallback=False)` keeps the current behavior when the key is missing or the file is absent, so this is not a behavior change for existing setups.

I also added an explicit `safe_mode = False` line to the sample `config.ini` so the key is discoverable.

Default stays `False` to avoid changing behavior for anyone who hasn't opted in.

## Testing

Added `tests/test_safe_mode.py` covering the three cases (key True, key False, key absent):

```
$ python3 -m pytest tests/test_safe_mode.py -v
tests/test_safe_mode.py::TestSafeMode::test_safe_mode_defaults_false_when_key_absent PASSED
tests/test_safe_mode.py::TestSafeMode::test_safe_mode_disabled_when_configured_false PASSED
tests/test_safe_mode.py::TestSafeMode::test_safe_mode_enabled_when_configured_true PASSED
3 passed in 0.02s
```

The pre-existing `test_utility.py` / `test_tools_parsing.py` failures are unrelated to this change. They come from `termcolor` not being importable in the test env, which was already noted in #470.
