### PR TITLE
feat(workspace): isolate agent file access from application source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ SEARXNG_BASE_URL="http://searxng:8080"
 SEARXNG_PORT=8080
 REDIS_BASE_URL="redis://redis:6379/0"
 WORK_DIR="/Users/username/Documents/workspace_with_my_files"
+# Runtime files (logs, screenshots, saved sessions). In Docker this is a named
+# volume at /opt/agent-runtime; on the host it defaults to ./.agent-data
+AGENT_RUNTIME_DIR=".agent-data"
 OLLAMA_PORT="11434"
 LM_STUDIO_PORT="1234"
 BACKEND_PORT="7777"

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ config.ini
 experimental/
 chrome_bundle/
 .logs/
-.screenshots/*.png
-.screenshots/*.jpg
+.screenshots/
+.agent-data/
 conversations/
 agentic_env/*
 agentic_seek_env/*

--- a/api.py
+++ b/api.py
@@ -21,6 +21,7 @@ from sources.browser import Browser, create_driver
 from sources.utility import pretty_print
 from sources.logger import Logger
 from sources.schemas import QueryRequest, QueryResponse
+from sources.workspace import runtime_subdir
 
 from dotenv import load_dotenv
 
@@ -67,9 +68,8 @@ api.add_middleware(
     allow_headers=["*"],
 )
 
-if not os.path.exists(".screenshots"):
-    os.makedirs(".screenshots")
-api.mount("/screenshots", StaticFiles(directory=".screenshots"), name="screenshots")
+SCREENSHOTS_DIR = runtime_subdir("screenshots")
+api.mount("/screenshots", StaticFiles(directory=SCREENSHOTS_DIR), name="screenshots")
 
 def initialize_system():
     stealth_mode = config.getboolean('BROWSER', 'stealth_mode')
@@ -154,7 +154,7 @@ query_resp_history = []
 @api.get("/screenshot")
 async def get_screenshot():
     logger.info("Screenshot endpoint called")
-    screenshot_path = ".screenshots/updated_screen.png"
+    screenshot_path = os.path.join(SCREENSHOTS_DIR, "updated_screen.png")
     if os.path.exists(screenshot_path):
         return FileResponse(screenshot_path)
     logger.error("No screenshot available")

--- a/config.ini
+++ b/config.ini
@@ -11,6 +11,8 @@ listen = False
 jarvis_personality = False
 languages = en
 safe_mode = False
+# Optional: agent workspace when WORK_DIR is not set in the environment.
+# work_dir = /path/to/your/workspace
 [BROWSER]
 headless_browser = True
 stealth_mode = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,13 +81,16 @@ services:
       # "0.0.0.0:${BACKEND_PORT}:${BACKEND_PORT}" and put it behind auth/a firewall.
       - 127.0.0.1:${BACKEND_PORT:-7777}:${BACKEND_PORT:-7777}
     volumes:
-      - ./:/app
-      - ${WORK_DIR:-.}:/opt/workspace
+      # Agent workspace: the only directory agents may read/write/execute in.
+      - ${WORK_DIR}:/opt/workspace
+      # Runtime data (logs, screenshots, sessions) — kept separate from app source.
+      - agent-runtime:/opt/agent-runtime
     command: python3 api.py
     environment:
       - SEARXNG_BASE_URL=${SEARXNG_BASE_URL:-http://searxng:8080}
       - REDIS_URL=${REDIS_BASE_URL:-redis://redis:6379/0}
       - WORK_DIR=/opt/workspace
+      - AGENT_RUNTIME_DIR=/opt/agent-runtime
       - BACKEND_PORT=${BACKEND_PORT}
       # Bind 0.0.0.0 *inside* the container so the loopback-only published port
       # (see the "ports" mapping above) can reach it. The host only exposes the
@@ -111,6 +114,7 @@ services:
 volumes:
   redis-data:
   chrome_profiles:
+  agent-runtime:
 
 networks:
   agentic-seek-net:

--- a/sources/browser.py
+++ b/sources/browser.py
@@ -31,6 +31,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from sources.utility import pretty_print, animate_thinking
 from sources.logger import Logger
+from sources.workspace import runtime_subdir
 
 
 def get_chrome_path() -> str:
@@ -288,7 +289,7 @@ class Browser:
         self.js_scripts_folder = "./sources/web_scripts/" if not __name__ == "__main__" else "./web_scripts/"
         self.anticaptcha = "https://chrome.google.com/webstore/detail/nopecha-captcha-solver/dknlfmjaanfblgfdfebhijalfmhmjjjo/related"
         self.logger = Logger("browser.log")
-        self.screenshot_folder = os.path.join(os.getcwd(), ".screenshots")
+        self.screenshot_folder = runtime_subdir("screenshots")
         self.tabs = []
         try:
             self.driver = driver

--- a/sources/logger.py
+++ b/sources/logger.py
@@ -3,9 +3,11 @@ from typing import List, Tuple, Type, Dict
 import datetime
 import logging
 
+from sources.workspace import runtime_subdir
+
 class Logger:
     def __init__(self, log_filename):
-        self.folder = '.logs'
+        self.folder = runtime_subdir("logs")
         self.create_folder(self.folder)
         self.log_path = os.path.join(self.folder, log_filename)
         self.enabled = True

--- a/sources/memory.py
+++ b/sources/memory.py
@@ -11,6 +11,7 @@ import configparser
 
 from sources.utility import timer_decorator, pretty_print, animate_thinking
 from sources.logger import Logger
+from sources.workspace import runtime_subdir
 
 config = configparser.ConfigParser()
 config.read('config.ini')
@@ -29,7 +30,7 @@ class Memory():
         self.logger = Logger("memory.log")
         self.session_time = datetime.datetime.now()
         self.session_id = str(uuid.uuid4())
-        self.conversation_folder = f"conversations/"
+        self.conversation_folder = runtime_subdir("conversations")
         self.session_recovered = False
         if recover_last_session:
             self.load_memory()

--- a/sources/tools/fileFinder.py
+++ b/sources/tools/fileFinder.py
@@ -27,8 +27,11 @@ class FileFinder(Tools):
             str: The content of the file
         """
         try:
-            with open(file_path, 'r') as file:
+            safe_path = self.resolve_path(file_path)
+            with open(safe_path, 'r') as file:
                 return file.read()
+        except PermissionError as e:
+            return f"Error reading file: {e}"
         except Exception as e:
             return f"Error reading file: {e}"
         
@@ -65,23 +68,26 @@ class FileFinder(Tools):
         Returns:
             str: A dictionary containing the file information
         """
-        if os.path.exists(file_path):
-            stats = os.stat(file_path)
-            permissions = oct(stat.S_IMODE(stats.st_mode))
-            file_type, _ = mimetypes.guess_type(file_path)
-            file_type = file_type if file_type else "Unknown"
-            content = self.read_arbitrary_file(file_path, file_type)
-            
-            result = {
-                "filename": os.path.basename(file_path),
-                "path": file_path,
-                "type": file_type,
-                "read": content,
-                "permissions": permissions
-            }
-            return result
-        else:
+        try:
+            safe_path = self.resolve_path(file_path)
+        except PermissionError as e:
+            return {"filename": file_path, "error": str(e)}
+        if not os.path.exists(safe_path):
             return {"filename": file_path, "error": "File not found"}
+        stats = os.stat(safe_path)
+        permissions = oct(stat.S_IMODE(stats.st_mode))
+        file_type, _ = mimetypes.guess_type(safe_path)
+        file_type = file_type if file_type else "Unknown"
+        content = self.read_arbitrary_file(safe_path, file_type)
+        
+        result = {
+            "filename": os.path.basename(safe_path),
+            "path": safe_path,
+            "type": file_type,
+            "read": content,
+            "permissions": permissions
+        }
+        return result
     
     def recursive_search(self, directory_path: str, filename: str) -> str:
         """
@@ -92,6 +98,10 @@ class FileFinder(Tools):
         Returns:
             str | None: The path to the file if found, None otherwise
         """
+        try:
+            directory_path = self.resolve_path(directory_path)
+        except PermissionError:
+            return None
         file_path = None
         excluded_files = [".pyc", ".o", ".so", ".a", ".lib", ".dll", ".dylib", ".so", ".git"]
         for root, dirs, files in os.walk(directory_path):

--- a/sources/tools/tools.py
+++ b/sources/tools/tools.py
@@ -26,6 +26,7 @@ if __name__ == "__main__": # if running as a script for individual testing
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from sources.logger import Logger
+from sources.workspace import ensure_work_dir, get_work_dir, resolve_workspace_path
 
 class Tools():
     """
@@ -50,28 +51,19 @@ class Tools():
     def set_allow_language_exec_bash(self, value: bool) -> None:
         self.allow_language_exec_bash = value 
 
-    def safe_get_work_dir_path(self):
-        path = None
-        path = os.getenv('WORK_DIR', path)
-        if path is None or path == "":
-            path = self.config['MAIN']['work_dir'] if 'MAIN' in self.config and 'work_dir' in self.config['MAIN'] else None
-        if path is None or path == "":
-            raise Exception("No work dir specified, please specify a work dir in .env file.")
-        return path
-    
     def config_exists(self):
         """Check if the config file exists."""
         return os.path.exists('./config.ini')
 
     def create_work_dir(self):
-        """Create the work directory if it does not exist."""
-        default_path = os.path.dirname(os.getcwd())
+        """Create and return the isolated agent workspace directory."""
         if self.config_exists():
             self.config.read('./config.ini')
-            workdir_path = self.safe_get_work_dir_path()
-        else:
-            workdir_path = default_path
-        return workdir_path
+        return ensure_work_dir()
+
+    def resolve_path(self, path: str) -> str:
+        """Resolve a path inside the agent workspace, rejecting escapes."""
+        return resolve_workspace_path(path, self.work_dir)
 
     @abstractmethod
     def execute(self, blocks:[str], safety:bool) -> str:
@@ -120,12 +112,16 @@ class Tools():
         self.logger.info(f"Saving blocks to {save_path}")
         save_path_dir = os.path.dirname(save_path)
         save_path_file = os.path.basename(save_path)
-        directory = os.path.join(self.work_dir, save_path_dir)
-        if directory and not os.path.exists(directory):
+        if save_path_dir:
+            directory = self.resolve_path(save_path_dir)
+        else:
+            directory = self.work_dir
+        file_path = self.resolve_path(os.path.join(directory, save_path_file))
+        if not os.path.exists(directory):
             self.logger.info(f"Creating directory {directory}")
             os.makedirs(directory)
         for block in blocks:
-            with open(os.path.join(directory, save_path_file), 'w') as f:
+            with open(file_path, 'w') as f:
                 f.write(block)
     
     def get_parameter_value(self, block: str, parameter_name: str) -> str:

--- a/sources/workspace.py
+++ b/sources/workspace.py
@@ -1,0 +1,93 @@
+"""
+Agent workspace and runtime directory resolution.
+
+Agents may only read/write files inside WORK_DIR. Application runtime data
+(logs, screenshots, conversation history) lives in AGENT_RUNTIME_DIR so the
+application source tree can stay read-only in Docker.
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+
+DEFAULT_RUNTIME_DIR = ".agent-data"
+
+
+def _read_config_work_dir() -> str | None:
+    if not os.path.exists("config.ini"):
+        return None
+    config = configparser.ConfigParser()
+    config.read("config.ini")
+    if "MAIN" not in config:
+        return None
+    value = config["MAIN"].get("work_dir", fallback="").strip()
+    return value or None
+
+
+def get_runtime_dir() -> str:
+    """Directory for backend runtime files (logs, screenshots, sessions)."""
+    path = os.getenv("AGENT_RUNTIME_DIR", DEFAULT_RUNTIME_DIR).strip()
+    if not path:
+        path = DEFAULT_RUNTIME_DIR
+    return os.path.realpath(os.path.abspath(path))
+
+
+def get_work_dir() -> str:
+    """Directory where agents may read, write, and execute code."""
+    path = os.getenv("WORK_DIR", "").strip() or _read_config_work_dir()
+    if not path:
+        path = os.path.join(get_runtime_dir(), "workspace")
+    return os.path.realpath(os.path.abspath(path))
+
+
+def ensure_directory(path: str) -> str:
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def ensure_work_dir() -> str:
+    return ensure_directory(get_work_dir())
+
+
+def ensure_runtime_dir() -> str:
+    return ensure_directory(get_runtime_dir())
+
+
+def runtime_subdir(name: str) -> str:
+    return ensure_directory(os.path.join(get_runtime_dir(), name))
+
+
+def is_within_directory(path: str, directory: str) -> bool:
+    """Return True when path resolves inside directory (no traversal escape)."""
+    try:
+        path_real = os.path.realpath(os.path.abspath(path))
+        dir_real = os.path.realpath(os.path.abspath(directory))
+        return os.path.commonpath([path_real, dir_real]) == dir_real
+    except ValueError:
+        return False
+
+
+def resolve_workspace_path(path: str, work_dir: str | None = None) -> str:
+    """
+    Resolve a user or model-provided path inside the agent workspace.
+
+    Raises:
+        ValueError: empty path
+        PermissionError: resolved path escapes the workspace
+    """
+    if path is None or not str(path).strip():
+        raise ValueError("Empty path")
+
+    base = work_dir or get_work_dir()
+    candidate = str(path).strip()
+    if os.path.isabs(candidate):
+        resolved = os.path.realpath(candidate)
+    else:
+        resolved = os.path.realpath(os.path.join(base, candidate))
+
+    if not is_within_directory(resolved, base):
+        raise PermissionError(
+            f"Path '{path}' is outside the agent workspace ({base})"
+        )
+    return resolved

--- a/start_services.sh
+++ b/start_services.sh
@@ -10,6 +10,14 @@ if [ -z "$WORK_DIR" ]; then
     exit 1
 fi
 
+work_dir_real=$(cd "$WORK_DIR" 2>/dev/null && pwd -P)
+repo_real=$(pwd -P)
+if [ -n "$work_dir_real" ] && [ "$work_dir_real" = "$repo_real" ]; then
+    echo "Error: WORK_DIR must not be the AgenticSeek repository root."
+    echo "Set WORK_DIR to a separate folder for agent file access, e.g. ~/Documents/agenticseek_workspace"
+    exit 1
+fi
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
     dir_size_bytes=$(du -s -b "$WORK_DIR" 2>/dev/null | awk '{print $1}')
 else

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -15,11 +15,11 @@ class TestLogger(unittest.TestCase):
         self.logger = Logger("test_logger.log")
 
     def tearDown(self):
-        if os.path.exists('.logs'):
+        if os.path.exists(self.logger.folder):
             for handler in self.logger.logger.handlers[:]:
                 handler.close()
                 self.logger.logger.removeHandler(handler)
-            log_path = os.path.join('.logs', 'test_logger.log')
+            log_path = os.path.join(self.logger.folder, 'test_logger.log')
             if os.path.exists(log_path):
                 os.remove(log_path)
 
@@ -27,7 +27,7 @@ class TestLogger(unittest.TestCase):
         """Test logger initializes correctly."""
         self.assertTrue(self.logger.enabled)
         self.assertIsNotNone(self.logger.logger)
-        self.assertTrue(os.path.exists('.logs'))
+        self.assertTrue(os.path.exists(self.logger.folder))
 
     def test_log_creates_file(self):
         """Test that logging creates a log file."""
@@ -84,7 +84,7 @@ class TestLogger(unittest.TestCase):
 
     def test_create_folder_already_exists(self):
         """Test folder creation when folder already exists."""
-        result = self.logger.create_folder('.logs')
+        result = self.logger.create_folder(self.logger.folder)
         self.assertTrue(result)
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import tempfile
+import shutil
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sources.workspace import (
+    ensure_work_dir,
+    get_runtime_dir,
+    get_work_dir,
+    is_within_directory,
+    resolve_workspace_path,
+    runtime_subdir,
+)
+from sources.tools.fileFinder import FileFinder
+
+
+class WorkspaceTestCase(unittest.TestCase):
+    def setUp(self):
+        self._root = tempfile.mkdtemp()
+        self._work_dir = os.path.join(self._root, "workspace")
+        self._runtime_dir = os.path.join(self._root, "runtime")
+        os.makedirs(self._work_dir)
+        self._old_work_dir = os.environ.get("WORK_DIR")
+        self._old_runtime_dir = os.environ.get("AGENT_RUNTIME_DIR")
+        os.environ["WORK_DIR"] = self._work_dir
+        os.environ["AGENT_RUNTIME_DIR"] = self._runtime_dir
+
+    def tearDown(self):
+        if self._old_work_dir is None:
+            os.environ.pop("WORK_DIR", None)
+        else:
+            os.environ["WORK_DIR"] = self._old_work_dir
+        if self._old_runtime_dir is None:
+            os.environ.pop("AGENT_RUNTIME_DIR", None)
+        else:
+            os.environ["AGENT_RUNTIME_DIR"] = self._old_runtime_dir
+        shutil.rmtree(self._root, ignore_errors=True)
+
+
+class TestWorkspacePaths(WorkspaceTestCase):
+    def test_work_dir_and_runtime_dir_are_separate(self):
+        self.assertEqual(get_work_dir(), os.path.realpath(self._work_dir))
+        self.assertEqual(get_runtime_dir(), os.path.realpath(self._runtime_dir))
+        self.assertNotEqual(get_work_dir(), get_runtime_dir())
+
+    def test_runtime_subdir_is_outside_work_dir(self):
+        logs_dir = runtime_subdir("logs")
+        self.assertTrue(logs_dir.startswith(get_runtime_dir()))
+        self.assertFalse(is_within_directory(logs_dir, get_work_dir()))
+
+    def test_resolve_workspace_path_blocks_traversal(self):
+        with self.assertRaises(PermissionError):
+            resolve_workspace_path("../../outside.txt")
+
+    def test_resolve_workspace_path_allows_relative_file(self):
+        target = os.path.join(self._work_dir, "notes.txt")
+        open(target, "w").close()
+        resolved = resolve_workspace_path("notes.txt")
+        self.assertEqual(resolved, os.path.realpath(target))
+
+    def test_ensure_work_dir_creates_missing_directory(self):
+        nested = os.path.join(self._root, "new_workspace")
+        os.environ["WORK_DIR"] = nested
+        self.assertEqual(ensure_work_dir(), os.path.realpath(nested))
+        self.assertTrue(os.path.isdir(nested))
+
+
+class TestFileFinderWorkspaceIsolation(WorkspaceTestCase):
+    def test_cannot_read_file_outside_workspace(self):
+        outside = os.path.join(self._root, "secret.txt")
+        with open(outside, "w") as handle:
+            handle.write("secret")
+
+        finder = FileFinder()
+        result = finder.get_file_info(outside)
+        self.assertIn("error", result)
+        self.assertIn("outside the agent workspace", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR introduces workspace isolation so agents operate in a dedicated `WORK_DIR` instead of the application source tree.

- Add `sources/workspace.py` to resolve `WORK_DIR` and `AGENT_RUNTIME_DIR`
- Remove the `./:/app` bind mount from the Docker backend; mount only the agent workspace and a dedicated runtime volume
- Move logs, screenshots, and conversation history under `AGENT_RUNTIME_DIR` (default: `.agent-data/`)
- Validate file tool paths to block directory traversal outside the workspace
- Reject `WORK_DIR` pointing at the repository root in `start_services.sh`

## Motivation

Agents can execute shell commands and read/write files. Previously, Docker mounted the entire repository into the backend container as a writable volume, so agents could potentially modify application source code.

This change separates:
- **Agent workspace** (`WORK_DIR`) — where agents read, write, and execute code
- **Runtime data** (`AGENT_RUNTIME_DIR`) — logs, screenshots, and saved sessions
- **Application source** — baked into the Docker image, no longer writable via bind mount

## Configuration

```env
WORK_DIR="/path/to/your/agent/workspace"
AGENT_RUNTIME_DIR=".agent-data"