### PR TITLE
feat(planner): spawn fresh sub-agents per task

### DIFF
--- a/api.py
+++ b/api.py
@@ -132,7 +132,9 @@ def initialize_system():
         PlannerAgent(
             name="Planner",
             prompt_path=f"prompts/{personality_folder}/planner_agent.txt",
-            provider=provider, verbose=False, browser=browser
+            provider=provider, verbose=False, browser=browser,
+            personality_folder=personality_folder,
+            casual_agent_name=config["MAIN"]["agent_name"],
         )
     ]
     logger.info("Agents initialized")

--- a/cli.py
+++ b/cli.py
@@ -48,7 +48,9 @@ async def main():
                      provider=provider, verbose=False, browser=browser),
         PlannerAgent(name="Planner",
                      prompt_path=f"prompts/{personality_folder}/planner_agent.txt",
-                     provider=provider, verbose=False, browser=browser),
+                     provider=provider, verbose=False, browser=browser,
+                     personality_folder=personality_folder,
+                     casual_agent_name=config["MAIN"]["agent_name"]),
         #McpAgent(name="MCP Agent",
         #            prompt_path=f"prompts/{personality_folder}/mcp_agent.txt",
         #            provider=provider, verbose=False), # NOTE under development

--- a/sources/agents/planner_agent.py
+++ b/sources/agents/planner_agent.py
@@ -1,20 +1,23 @@
 import json
-from typing import List, Tuple, Type, Dict
+from typing import List, Tuple, Dict
+
 from sources.utility import pretty_print, animate_thinking
 from sources.agents.agent import Agent
-from sources.agents.code_agent import CoderAgent
-from sources.agents.file_agent import FileAgent
-from sources.agents.browser_agent import BrowserAgent
-from sources.agents.casual_agent import CasualAgent
 from sources.text_to_speech import Speech
 from sources.tools.tools import Tools
 from sources.logger import Logger
 from sources.memory import Memory
 
+SUB_AGENT_KEYS = ("coder", "file", "web", "casual")
+
+
 class PlannerAgent(Agent):
-    def __init__(self, name, prompt_path, provider, verbose=False, browser=None):
+    def __init__(self, name, prompt_path, provider, verbose=False, browser=None,
+                 personality_folder=None, casual_agent_name=None):
         """
         The planner agent is a special agent that divides and conquers the task.
+        Sub-agents are spawned per task so memory and tool state do not leak
+        between planner steps or user requests.
         """
         super().__init__(name, prompt_path, provider, verbose, None)
         self.tools = {
@@ -22,12 +25,9 @@ class PlannerAgent(Agent):
         }
         self.tools['json'].tag = "json"
         self.browser = browser
-        self.agents = {
-            "coder": CoderAgent(name, "prompts/base/coder_agent.txt", provider, verbose=False),
-            "file": FileAgent(name, "prompts/base/file_agent.txt", provider, verbose=False),
-            "web": BrowserAgent(name, "prompts/base/browser_agent.txt", provider, verbose=False, browser=browser),
-            "casual": CasualAgent(name, "prompts/base/casual_agent.txt", provider, verbose=False)
-        }
+        self.personality_folder = personality_folder or self.personality_from_prompt(prompt_path)
+        self.casual_agent_name = casual_agent_name or name
+        self._active_sub_agent = None
         self.role = "planification"
         self.type = "planner_agent"
         self.memory = Memory(self.load_prompt(prompt_path),
@@ -35,6 +35,53 @@ class PlannerAgent(Agent):
                                 memory_compression=False,
                                 model_provider=provider.get_model_name())
         self.logger = Logger("planner_agent.log")
+
+    def request_stop(self) -> None:
+        """Stop the planner and any sub-agent currently executing a task."""
+        super().request_stop()
+        if self._active_sub_agent is not None:
+            self._active_sub_agent.request_stop()
+
+    @staticmethod
+    def personality_from_prompt(prompt_path: str) -> str:
+        """Derive prompts/<personality>/ from a planner prompt path."""
+        parts = prompt_path.replace("\\", "/").split("/")
+        if len(parts) >= 3 and parts[0] == "prompts":
+            return parts[1]
+        return "base"
+
+    def supported_sub_agents(self) -> Tuple[str, ...]:
+        return SUB_AGENT_KEYS
+
+    def create_sub_agent(self, agent_key: str) -> Agent:
+        """Create a fresh sub-agent instance for a single planner task."""
+        key = agent_key.lower()
+        if key not in SUB_AGENT_KEYS:
+            raise ValueError(f"Unknown sub-agent: {agent_key}")
+
+        prompts = f"prompts/{self.personality_folder}"
+        if key == "coder":
+            from sources.agents.code_agent import CoderAgent
+            return CoderAgent("coder", f"{prompts}/coder_agent.txt", self.llm, self.verbose)
+        if key == "file":
+            from sources.agents.file_agent import FileAgent
+            return FileAgent("File Agent", f"{prompts}/file_agent.txt", self.llm, self.verbose)
+        if key == "web":
+            from sources.agents.browser_agent import BrowserAgent
+            return BrowserAgent(
+                "Browser",
+                f"{prompts}/browser_agent.txt",
+                self.llm,
+                self.verbose,
+                browser=self.browser,
+            )
+        from sources.agents.casual_agent import CasualAgent
+        return CasualAgent(
+            self.casual_agent_name,
+            f"{prompts}/casual_agent.txt",
+            self.llm,
+            self.verbose,
+        )
 
     def get_task_names(self, text: str) -> List[str]:
         """
@@ -84,7 +131,7 @@ class PlannerAgent(Agent):
                 return []
             if 'plan' in line_json:
                 for task in line_json['plan']:
-                    if task['agent'].lower() not in [ag_name.lower() for ag_name in self.agents.keys()]:
+                    if task['agent'].lower() not in SUB_AGENT_KEYS:
                         self.logger.warning(f"Agent {task['agent']} does not exist.")
                         pretty_print(f"Agent {task['agent']} does not exist.", color="warning")
                         return []
@@ -94,7 +141,7 @@ class PlannerAgent(Agent):
                             'id': task['id'],
                             'task': task['task']
                         }
-                    except:
+                    except Exception:
                         self.logger.warning("Missing field in json plan.")
                         return []
                     self.logger.info(f"Created agent {task['agent']} with task: {task['task']}")
@@ -197,7 +244,7 @@ class PlannerAgent(Agent):
         pretty_print(f"Agent {id} work {tool_success_str}.", color="success" if success else "failure")
         try:
             id_int = int(id)
-        except Exception as e:
+        except Exception:
             return agents_tasks
         if id_int == len(agents_tasks):
             next_task = "No task follow, this was the last step. If it failed add a task to recover."
@@ -242,13 +289,21 @@ class PlannerAgent(Agent):
         agent_prompt = self.make_prompt(task['task'], required_infos)
         pretty_print(f"Agent {task['agent']} started working...", color="status")
         self.logger.info(f"Agent {task['agent']} started working on {task['task']}.")
-        answer, reasoning = await self.agents[task['agent'].lower()].process(agent_prompt, None)
+
+        sub_agent = self.create_sub_agent(task['agent'])
+        self._active_sub_agent = sub_agent
+        if self.stop:
+            sub_agent.request_stop()
+        try:
+            answer, reasoning = await sub_agent.process(agent_prompt, None)
+        finally:
+            self._active_sub_agent = None
         self.last_answer = answer
         self.last_reasoning = reasoning
-        self.blocks_result = self.agents[task['agent'].lower()].blocks_result
-        agent_answer = self.agents[task['agent'].lower()].raw_answer_blocks(answer)
-        success = self.agents[task['agent'].lower()].get_success
-        self.agents[task['agent'].lower()].show_answer()
+        self.blocks_result = sub_agent.blocks_result
+        agent_answer = sub_agent.raw_answer_blocks(answer)
+        success = sub_agent.get_success
+        sub_agent.show_answer()
         pretty_print(f"Agent {task['agent']} completed task.", color="status")
         self.logger.info(f"Agent {task['agent']} finished working on {task['task']}. Success: {success}")
         agent_answer += "\nAgent succeeded with task." if success else "\nAgent failed with task (Error detected)."
@@ -279,6 +334,7 @@ class PlannerAgent(Agent):
             return "Failed to parse the tasks.", ""
         i = 0
         steps = len(agents_tasks)
+        answer = ""
         while i < steps and not self.stop:
             task_name, task = agents_tasks[i][0], agents_tasks[i][1]
             self.status_message = "Starting agents..."

--- a/tests/test_planner_agent_parsing.py
+++ b/tests/test_planner_agent_parsing.py
@@ -14,7 +14,7 @@ for mod_name in [
     'pypdf', 'langid', 'pypinyin', 'fake_useragent',
     'chromedriver_autoinstaller', 'num2words', 'sentencepiece', 'sacremoses',
     'scipy', 'numpy', 'selenium_stealth', 'undetected_chromedriver',
-    'markdownify',
+    'markdownify', 'termcolor',
 ]:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = MagicMock()
@@ -32,12 +32,6 @@ class TestPlannerAgentParsing(unittest.TestCase):
         self.agent.tools = {"json": MagicMock()}
         self.agent.tools["json"].tag = "json"
         self.agent.logger = MagicMock()
-        self.agent.agents = {
-            "coder": MagicMock(),
-            "file": MagicMock(),
-            "web": MagicMock(),
-            "casual": MagicMock()
-        }
 
     def test_parse_valid_json(self):
         """Test that valid JSON plan is parsed correctly."""

--- a/tests/test_planner_agent_stateless.py
+++ b/tests/test_planner_agent_stateless.py
@@ -1,0 +1,132 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+for mod_name in [
+    "torch", "transformers", "kokoro", "adaptive_classifier", "text2emotion",
+    "ollama", "openai", "together", "IPython", "IPython.display",
+    "playsound3", "soundfile", "pyaudio", "librosa",
+    "pypdf", "langid", "pypinyin", "fake_useragent",
+    "chromedriver_autoinstaller", "num2words", "sentencepiece", "sacremoses",
+    "scipy", "numpy", "selenium_stealth", "undetected_chromedriver",
+    "markdownify", "termcolor",
+]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = MagicMock()
+
+os.environ.setdefault("WORK_DIR", "/tmp")
+
+from sources.agents.planner_agent import PlannerAgent, SUB_AGENT_KEYS
+
+
+class TestPlannerAgentStateless(unittest.TestCase):
+    def setUp(self):
+        self.planner = PlannerAgent.__new__(PlannerAgent)
+        self.planner.llm = MagicMock()
+        self.planner.verbose = False
+        self.planner.browser = MagicMock()
+        self.planner.personality_folder = "jarvis"
+        self.planner.casual_agent_name = "Jarvis"
+        self.planner.stop = False
+        self.planner._active_sub_agent = None
+
+    def test_personality_from_prompt(self):
+        self.assertEqual(
+            PlannerAgent.personality_from_prompt("prompts/jarvis/planner_agent.txt"),
+            "jarvis",
+        )
+        self.assertEqual(
+            PlannerAgent.personality_from_prompt("prompts/base/planner_agent.txt"),
+            "base",
+        )
+
+    def test_create_sub_agent_uses_personality_folder(self):
+        with patch("sources.agents.code_agent.CoderAgent") as coder_cls:
+            coder_cls.return_value = MagicMock()
+            self.planner.create_sub_agent("coder")
+
+        coder_cls.assert_called_once_with(
+            "coder",
+            "prompts/jarvis/coder_agent.txt",
+            self.planner.llm,
+            self.planner.verbose,
+        )
+
+    def test_create_sub_agent_casual_uses_configured_name(self):
+        with patch("sources.agents.casual_agent.CasualAgent") as casual_cls:
+            casual_cls.return_value = MagicMock()
+            self.planner.create_sub_agent("casual")
+
+        casual_cls.assert_called_once_with(
+            "Jarvis",
+            "prompts/jarvis/casual_agent.txt",
+            self.planner.llm,
+            self.planner.verbose,
+        )
+
+    def test_create_sub_agent_rejects_unknown_agent(self):
+        with self.assertRaises(ValueError):
+            self.planner.create_sub_agent("unknown")
+
+    def test_start_agent_process_spawns_fresh_agent_each_call(self):
+        self.planner.make_prompt = MagicMock(return_value="do work")
+        self.planner.status_message = ""
+        self.planner.logger = MagicMock()
+        self.planner.last_answer = ""
+        self.planner.last_reasoning = ""
+        self.planner.blocks_result = []
+
+        def make_agent(_key):
+            agent = MagicMock()
+            agent.process = AsyncMock(return_value=("done", ""))
+            agent.blocks_result = []
+            agent.get_success = True
+            agent.raw_answer_blocks = MagicMock(return_value="done")
+            return agent
+
+        with patch.object(self.planner, "create_sub_agent", side_effect=make_agent) as create_mock:
+            import asyncio
+
+            task = {"agent": "coder", "task": "write code"}
+            asyncio.run(self.planner.start_agent_process(task, None))
+            asyncio.run(self.planner.start_agent_process(task, None))
+
+        self.assertEqual(create_mock.call_count, 2)
+
+    def test_supported_sub_agents_matches_keys(self):
+        self.assertEqual(self.planner.supported_sub_agents(), SUB_AGENT_KEYS)
+
+    def test_request_stop_propagates_to_active_sub_agent(self):
+        sub_agent = MagicMock()
+        self.planner._active_sub_agent = sub_agent
+        self.planner.status_message = ""
+        PlannerAgent.request_stop(self.planner)
+        sub_agent.request_stop.assert_called_once()
+        self.assertTrue(self.planner.stop)
+
+    def test_start_agent_process_propagates_stop_to_sub_agent(self):
+        self.planner.make_prompt = MagicMock(return_value="do work")
+        self.planner.status_message = ""
+        self.planner.logger = MagicMock()
+        self.planner.stop = True
+
+        sub_agent = MagicMock()
+        sub_agent.process = AsyncMock(return_value=("stopped", ""))
+        sub_agent.blocks_result = []
+        sub_agent.get_success = False
+        sub_agent.raw_answer_blocks = MagicMock(return_value="stopped")
+
+        with patch.object(self.planner, "create_sub_agent", return_value=sub_agent):
+            import asyncio
+
+            task = {"agent": "coder", "task": "write code"}
+            asyncio.run(self.planner.start_agent_process(task, None))
+
+        sub_agent.request_stop.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Spawn a fresh coder/file/web/casual sub-agent for each planner task
- Use configured `personality_folder` and `casual_agent_name` instead of hardcoded `prompts/base/`
- Propagate stop requests from the planner to the active sub-agent

## Motivation
Reused sub-agents leaked memory and tool state between planner steps. Sub-agents also ignored `jarvis_personality` and always used base prompts. Stop requests did not reach the sub-agent currently executing a task.

## Test plan
- [x] `python -m unittest tests.test_planner_agent_stateless tests.test_planner_agent_parsing`
- [ ] Run a multi-step planner task via `cli.py`
- [ ] Click Stop while a sub-agent is running and verify execution halts