### PR TITLE
fix(providers): forward the configured model in deepseek_fn

### DIFF
--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -335,7 +335,7 @@ class Provider:
             raise Exception("Deepseek (API) is not available for local use. Change config.ini")
         try:
             response = client.chat.completions.create(
-                model="deepseek-chat",
+                model=self.model,
                 messages=history,
                 stream=False
             )

--- a/tests/test_deepseek_provider.py
+++ b/tests/test_deepseek_provider.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sources.llm_provider import Provider
+
+
+class TestDeepseekProvider(unittest.TestCase):
+    """Test cases for Deepseek provider integration."""
+
+    @patch('sources.llm_provider.OpenAI')
+    @patch.dict(os.environ, {'DEEPSEEK_API_KEY': 'test-key'})
+    def test_deepseek_forwards_configured_model(self, mock_openai_class):
+        """deepseek_fn must send the configured model, not a hardcoded literal."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Hello!"))]
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch.object(Provider, 'get_api_key', return_value='test-key'):
+            provider = Provider("deepseek", "deepseek-reasoner", is_local=False)
+            history = [{"role": "user", "content": "Hello"}]
+            provider.deepseek_fn(history)
+
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            self.assertEqual(call_kwargs['model'], "deepseek-reasoner")
+
+    @patch('sources.llm_provider.OpenAI')
+    @patch.dict(os.environ, {'DEEPSEEK_API_KEY': 'test-key'})
+    def test_deepseek_local_not_supported(self, mock_openai_class):
+        """Test that deepseek provider raises error when is_local=True."""
+        provider = Provider("deepseek", "deepseek-chat", is_local=True)
+        provider.api_key = 'test-key'
+        history = [{"role": "user", "content": "Hello"}]
+        with self.assertRaises(Exception) as context:
+            provider.deepseek_fn(history)
+        self.assertIn("not available for local use", str(context.exception))
+
+    @patch('sources.llm_provider.OpenAI')
+    @patch.dict(os.environ, {'DEEPSEEK_API_KEY': 'test-key'})
+    def test_deepseek_returns_response_content(self, mock_openai_class):
+        """Test that deepseek provider returns response content."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Test response"))]
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch.object(Provider, 'get_api_key', return_value='test-key'):
+            provider = Provider("deepseek", "deepseek-chat", is_local=False)
+            history = [{"role": "user", "content": "Hello"}]
+            result = provider.deepseek_fn(history)
+
+            self.assertEqual(result, "Test response")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`Provider.deepseek_fn` hardcoded `model="deepseek-chat"` instead of `self.model`, so `config.ini`'s `provider_model` (e.g. `deepseek-reasoner`) was silently ignored for every DeepSeek request, with no error or warning. Every other cloud provider function in the same class (`openai_fn`, `google_fn`, `together_fn`, `openrouter_fn`, `minimax_fn`, `litellm_fn`) already forwards `self.model`; `deepseek_fn` was the one exception.

Invariant restored: the model a `Provider` is constructed with is the model every provider function actually sends to the API.

Fix: one line, `model="deepseek-chat"` -> `model=self.model` in `sources/llm_provider.py`.

Verified in a clean `python:3.12-slim` Docker container: the added regression test (`tests/test_deepseek_provider.py`) mocks only the `OpenAI` client boundary and drives the real `deepseek_fn`. It fails on main (asserts the call receives the configured model, gets the hardcoded literal instead) and passes with this change. Also ran the full `tests/test_provider.py` suite alongside it, unaffected.

Fixes #530
