### PR TITLE
fix(api): require a bearer token on /query when AGENTICSEEK_API_TOKEN is set

### DIFF
--- a/api.py
+++ b/api.py
@@ -7,13 +7,14 @@ import configparser
 import asyncio
 import time
 from typing import List
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 import uuid
 
+from sources.api_auth import require_api_token
 from sources.llm_provider import Provider
 from sources.interaction import Interaction
 from sources.agents import CasualAgent, CoderAgent, FileAgent, PlannerAgent, BrowserAgent
@@ -226,7 +227,11 @@ async def think_wrapper(interaction, query):
         interaction.last_success = False
         raise e
 
-@api.post("/query", response_model=QueryResponse)
+@api.post(
+    "/query",
+    response_model=QueryResponse,
+    dependencies=[Depends(require_api_token)],
+)
 async def process_query(request: QueryRequest):
     global is_generating, query_resp_history
     logger.info(f"Processing query: {request.query}")

--- a/sources/api_auth.py
+++ b/sources/api_auth.py
@@ -1,0 +1,28 @@
+"""Shared-secret bearer token guard for sensitive AgenticSeek API routes.
+
+Off by default: if AGENTICSEEK_API_TOKEN is unset, every request passes,
+matching the existing local-only UX. Set AGENTICSEEK_API_TOKEN to require a
+matching `Authorization: Bearer <token>` header on routes that depend on
+require_api_token.
+"""
+
+import hmac
+import os
+
+from fastapi import Header, HTTPException
+
+
+async def require_api_token(authorization: str | None = Header(default=None)) -> None:
+    expected_token = os.getenv("AGENTICSEEK_API_TOKEN")
+    if not expected_token:
+        return
+
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Missing or malformed Authorization header",
+        )
+
+    provided_token = authorization[len("Bearer "):]
+    if not hmac.compare_digest(provided_token, expected_token):
+        raise HTTPException(status_code=401, detail="Invalid API token")

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from sources.api_auth import require_api_token
+
+
+def _build_protected_app():
+    app = FastAPI()
+
+    @app.post("/protected", dependencies=[Depends(require_api_token)])
+    async def protected():
+        return {"ok": True}
+
+    return app
+
+
+class TestApiAuth(unittest.TestCase):
+    """Regression tests for the AGENTICSEEK_API_TOKEN guard (#520)."""
+
+    def setUp(self):
+        self._previous_token = os.environ.pop("AGENTICSEEK_API_TOKEN", None)
+        self.client = TestClient(_build_protected_app())
+
+    def tearDown(self):
+        if self._previous_token is not None:
+            os.environ["AGENTICSEEK_API_TOKEN"] = self._previous_token
+        else:
+            os.environ.pop("AGENTICSEEK_API_TOKEN", None)
+
+    def test_no_token_configured_allows_request(self):
+        response = self.client.post("/protected")
+        self.assertEqual(response.status_code, 200)
+
+    def test_token_configured_rejects_missing_header(self):
+        os.environ["AGENTICSEEK_API_TOKEN"] = "s3cret"
+        response = self.client.post("/protected")
+        self.assertEqual(response.status_code, 401)
+
+    def test_token_configured_rejects_malformed_header(self):
+        os.environ["AGENTICSEEK_API_TOKEN"] = "s3cret"
+        response = self.client.post("/protected", headers={"Authorization": "s3cret"})
+        self.assertEqual(response.status_code, 401)
+
+    def test_token_configured_rejects_wrong_token(self):
+        os.environ["AGENTICSEEK_API_TOKEN"] = "s3cret"
+        response = self.client.post(
+            "/protected", headers={"Authorization": "Bearer wrong"}
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_token_configured_accepts_correct_token(self):
+        os.environ["AGENTICSEEK_API_TOKEN"] = "s3cret"
+        response = self.client.post(
+            "/protected", headers={"Authorization": "Bearer s3cret"}
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause

`POST /query` had no auth dependency at all (`api.py:229`, verified on HEAD `f18f147`). AgenticSeek's coder agent executes LLM-produced shell/Python code, so any caller that can reach the port can drive it: reaching the endpoint is equivalent to unauthenticated remote code execution.

PR #508 (merged) fixed *who can reach the port*: bind to `127.0.0.1` by default, drop the wildcard CORS origin. It intentionally left this half open, and the maintainer confirmed it directly on this issue: "yes `/query` is still not protected... I (or willing contributors) will ship authentication token on the API."

## Fix

Adds `sources/api_auth.require_api_token`, a FastAPI dependency checking a shared-secret bearer token from `AGENTICSEEK_API_TOKEN` (constant-time comparison via `hmac.compare_digest`). It is off by default: when the env var is unset, every request passes, so today's local-only UX is unchanged. Wired onto `/query` only via `dependencies=[Depends(require_api_token)]`, since that is the route that reaches the interpreters.

Deliberately left out of scope: `/screenshot`, `/stop`, `/latest_answer`, `/is_active` return status/output data or stop a running task rather than execute new code; extending the same guard to them is a reasonable follow-up but a separate design call (which ones, if any, should also require the token) that I didn't want to bundle into this fix.

## Verification

- Confirmed the defect end-to-end against the real `api` FastAPI instance (not just by reading the source): imported `api.py` with the browser/LLM-provider modules stubbed out (no real Selenium/model backend available in this environment) and inspected `api.routes` for `/query`. On unmodified `main`, its dependency list is empty; after this change, it includes `require_api_token`.
- `tests/test_api_auth.py` (new, 5 cases) exercises the dependency itself with a real `fastapi.testclient.TestClient`: no token configured -> allowed; token configured + missing/malformed/wrong header -> 401; token configured + correct `Bearer` header -> 200. All pass.
- Ran the existing `tests/test_utility.py`, `tests/test_workspace.py`, `tests/test_logger.py` alongside the new test (25/25 pass) as a smoke check; did not run the full suite locally, since several existing test modules import `torch`/`selenium`/audio libraries not installed in this environment.
- Did not boot the real server end-to-end with a live LLM provider and browser driver (not available here), so the actual `/query` request/response cycle under load is unverified; only the auth-gate wiring and behavior are.

Fixes #520
