### PR TITLE
Add MiniMax Anthropic-compatible endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,5 +38,6 @@ GOOGLE_API_KEY='xxxxx'
 ANTHROPIC_API_KEY='xxxxx'
 MINIMAX_API_KEY='xxxxx'
 # Optional: MiniMax API base URL (default: https://api.minimax.io/v1)
-# For mainland China users: https://api.minimaxi.com/v1
+# Anthropic-compatible: https://api.minimax.io/anthropic or https://api.minimaxi.com/anthropic
+# OpenAI-compatible for mainland China users: https://api.minimaxi.com/v1
 # MINIMAX_BASE_URL='https://api.minimax.io/v1'

--- a/sources/llm_provider.py
+++ b/sources/llm_provider.py
@@ -440,7 +440,7 @@ class Provider:
 
     def minimax_fn(self, history, verbose=False):
         """
-        Use MiniMax API to generate text via OpenAI-compatible interface.
+        Use MiniMax API through its OpenAI- or Anthropic-compatible interface.
 
         Supported models:
         - MiniMax-M3: Latest flagship model with enhanced reasoning and coding (default)
@@ -452,18 +452,48 @@ class Provider:
         load_dotenv()
         base_url = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
 
-        client = OpenAI(api_key=self.api_key, base_url=base_url)
         if self.is_local:
             raise Exception("MiniMax is not available for local use. Change config.ini")
         try:
-            response = client.chat.completions.create(
-                model=self.model,
-                messages=history,
-                temperature=1.0,
-            )
+            if base_url.rstrip("/").endswith("/anthropic"):
+                system_message = None
+                messages = []
+                for message in history:
+                    if message["role"] == "system":
+                        system_message = message["content"]
+                    else:
+                        messages.append(message)
+                payload = {
+                    "model": self.model,
+                    "max_tokens": 1024,
+                    "messages": messages,
+                    "temperature": 1.0,
+                }
+                if system_message is not None:
+                    payload["system"] = system_message
+                response = requests.post(
+                    f"{base_url.rstrip('/')}/v1/messages",
+                    headers={"Content-Type": "application/json", "X-Api-Key": self.api_key},
+                    json=payload,
+                    timeout=30,
+                )
+                response.raise_for_status()
+                content = response.json().get("content", [])
+                thought = "".join(
+                    block.get("text", "") for block in content if block.get("type") == "text"
+                )
+            else:
+                client = OpenAI(api_key=self.api_key, base_url=base_url)
+                response = client.chat.completions.create(
+                    model=self.model,
+                    messages=history,
+                    temperature=1.0,
+                )
+                thought = response.choices[0].message.content if response is not None else None
             if response is None:
                 raise Exception("MiniMax response is empty.")
-            thought = response.choices[0].message.content
+            if not thought:
+                raise Exception("MiniMax response is empty.")
             if verbose:
                 print(thought)
             return thought

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -84,6 +84,49 @@ class TestMiniMaxProvider(unittest.TestCase):
                 base_url='https://api.minimaxi.com/v1'
             )
 
+    @patch('sources.llm_provider.requests.post')
+    def test_minimax_anthropic_compatible_base_urls(self, mock_post):
+        """Test the MiniMax Anthropic-compatible endpoints in both regions."""
+        mock_post.return_value.json.return_value = {
+            "content": [
+                {"type": "thinking", "thinking": "Reasoning"},
+                {"type": "text", "text": "Hello!"},
+            ]
+        }
+        history = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+
+        for base_url in (
+            'https://api.minimax.io/anthropic',
+            'https://api.minimaxi.com/anthropic',
+        ):
+            with self.subTest(base_url=base_url), patch.dict(
+                os.environ, {'MINIMAX_BASE_URL': base_url}
+            ):
+                mock_post.reset_mock()
+                with patch.object(Provider, 'get_api_key', return_value='test-key'):
+                    provider = Provider("minimax", "MiniMax-M3", is_local=False)
+                    result = provider.minimax_fn(history)
+
+                self.assertEqual(result, "Hello!")
+                mock_post.assert_called_once_with(
+                    f'{base_url}/v1/messages',
+                    headers={
+                        'Content-Type': 'application/json',
+                        'X-Api-Key': 'test-key',
+                    },
+                    json={
+                        'model': 'MiniMax-M3',
+                        'max_tokens': 1024,
+                        'messages': [{"role": "user", "content": "Hello"}],
+                        'temperature': 1.0,
+                        'system': 'Be helpful.',
+                    },
+                    timeout=30,
+                )
+
     @patch('sources.llm_provider.OpenAI')
     @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
     def test_minimax_uses_temperature_one(self, mock_openai_class):


### PR DESCRIPTION
Reason: MiniMax text provider uses OpenAI-compatible base URLs only and lacks the target Anthropic-compatible base URL path.

This preserves the existing OpenAI-compatible integration and routes MiniMax `/anthropic` base URLs through the Messages API. System messages are separated into the compatible top-level field, text response blocks are collected, and both global and China endpoint examples are documented and tested.

Checks:

- `.venv/bin/python -m pytest tests/test_minimax_provider.py -q`
- `.venv/bin/python -m compileall -q sources/llm_provider.py`
- `git diff --check`
- Secret scan on the changed files
