### PR TITLE
fix: Fosowl/agenticSeek#494

### DIFF
--- a/tests/test_safe_mode.py
+++ b/tests/test_safe_mode.py
@@ -7,6 +7,7 @@ import shutil
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from sources.tools.tools import Tools
+from sources.tools.BashInterpreter import BashInterpreter
 
 
 class _SafeModeTool(Tools):
@@ -50,6 +51,24 @@ class TestSafeMode(unittest.TestCase):
     def test_safe_mode_defaults_false_when_key_absent(self):
         self._write_config("")
         self.assertFalse(_SafeModeTool().safe_mode)
+
+    def test_safe_mode_configured_true_rejects_unsafe_bash_command(self):
+        """End-to-end: the safe_mode flag read from config.ini must reach the
+        BashInterpreter's unsafe-command check. Before the fix, safe_mode was
+        hardcoded False, so is_unsafe() never ran in the default bash path."""
+        self._write_config("safe_mode = True\n")
+        bash = BashInterpreter()
+        self.assertTrue(bash.safe_mode)
+        output = bash.execute(["rm -rf some_dir"])
+        self.assertIn("Unsafe command: rm -rf some_dir", output)
+
+    def test_safe_mode_configured_true_aborts_whole_batch(self):
+        self._write_config("safe_mode = True\n")
+        bash = BashInterpreter()
+        marker = os.path.join(self._dir, "should_not_exist.txt")
+        output = bash.execute([f"touch {marker}", "rm -rf some_dir"])
+        self.assertIn("rm -rf some_dir", output)
+        self.assertFalse(os.path.exists(marker))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The automatic unsafe-command check was never running in the default bash execution path. `safe_mode` was hardcoded to `False` in the `Tools` base class and never set to `True` anywhere, so `is_unsafe()` inside `BashInterpreter.execute()` was unreachable during normal agent operation — meaning commands like `rm`, `dd`, or `chmod` were executed without any filtering.

This change sources `safe_mode` from `config.ini` (`[MAIN] safe_mode`, default `False`) so the flag actually reaches the bash interpreter, and adds end-to-end regression tests that prove the unsafe-command check runs and blocks execution.

## Why it fixes the issue

Issue #494 reported that the automatic unsafe-command detection never ran in the default path. The root cause wasn't a missing check — `BashInterpreter` already had the safe-mode validation — it was that the flag could never be enabled because nothing read it from configuration. Wiring `safe_mode` to `config.ini` makes the guard reachable in the normal flow.

The change stays opt-in: setups without the config key keep the existing behavior (`fallback=False`), while anyone who sets `safe_mode = True` gets the full batch validated up front.

## Verification

New tests write a `config.ini` with `safe_mode = True` and assert:
- `BashInterpreter.safe_mode` reflects the configured value.
- An unsafe command (`rm -rf some_dir`) is rejected with an "Unsafe command" message and never executed.
- The whole batch aborts in safe mode: a benign `touch` command in the same batch as an unsafe one does **not** run.

Ran `python3 -m unittest tests.test_safe_mode` — all 5 tests pass.

## Implementation notes

- `safe_mode` is read in `Tools.__init__` via `configparser.getboolean('MAIN', 'safe_mode', fallback=False)`.
- Tests run in a temporary working directory so they don't touch the real agent workspace.

Closes #494.