### PR TITLE
docs: fix broken star history chart in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,4 +785,4 @@ See [Contributing.md](./docs/CONTRIBUTING.md) to learn how to integrate custom t
 
  > [tcsenpai](https://github.com/tcsenpai) and [plitc](https://github.com/plitc) For helping with backend dockerization
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fosowl/agenticSeek&type=Date)](https://www.star-history.com/#Fosowl/agenticSeek&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fosowl/agenticSeek&type=Date)](https://star-history.dera.page/#Fosowl/agenticSeek&Date)

--- a/README_CHS.md
+++ b/README_CHS.md
@@ -693,4 +693,4 @@ X 上除了我的个人账户（https://x.com/Martin993886460）之外的任何 
 
  > [tcsenpai](https://github.com/tcsenpai) 和 [plitc](https://github.com/plitc) 协助后端 Docker 化
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fosowl/agenticSeek&type=Date)](https://www.star-history.com/#Fosowl/agenticSeek&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fosowl/agenticSeek&type=Date)](https://star-history.dera.page/#Fosowl/agenticSeek&Date)

--- a/README_CHT.md
+++ b/README_CHT.md
@@ -692,4 +692,4 @@ X 上除了我的個人賬戶（https://x.com/Martin993886460）之外的任何 
 
  > [tcsenpai](https://github.com/tcsenpai) 和 [plitc](https://github.com/plitc) 協助後端 Docker 化
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fosowl/agenticSeek&type=Date)](https://www.star-history.com/#Fosowl/agenticSeek&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fosowl/agenticSeek&type=Date)](https://star-history.dera.page/#Fosowl/agenticSeek&Date)

--- a/README_ES.md
+++ b/README_ES.md
@@ -691,4 +691,4 @@ Cualquier cuenta de AgenticSeek en X además de mi cuenta personal (https://x.co
 
  > [tcsenpai](https://github.com/tcsenpai) y [plitc](https://github.com/plitc) por ayudar con la dockerización del backend
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fosowl/agenticSeek&type=Date)](https://www.star-history.com/#Fosowl/agenticSeek&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fosowl/agenticSeek&type=Date)](https://star-history.dera.page/#Fosowl/agenticSeek&Date)

--- a/README_FR.md
+++ b/README_FR.md
@@ -691,4 +691,4 @@ Consultez [Contributing.md](./docs/CONTRIBUTING.md) pour apprendre comment inté
 
  > [tcsenpai](https://github.com/tcsenpai) et [plitc](https://github.com/plitc) pour avoir aidé à la dockerisation du backend
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fosowl/agenticSeek&type=Date)](https://www.star-history.com/#Fosowl/agenticSeek&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fosowl/agenticSeek&type=Date)](https://star-history.dera.page/#Fosowl/agenticSeek&Date)

--- a/README_JP.md
+++ b/README_JP.md
@@ -692,4 +692,4 @@ AgenticSeekを改善する開発者を探しています！オープンなissue�
 
  > [tcsenpai](https://github.com/tcsenpai) と [plitc](https://github.com/plitc) がバックエンドのDocker化を支援
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fosowl/agenticSeek&type=Date)](https://www.star-history.com/#Fosowl/agenticSeek&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fosowl/agenticSeek&type=Date)](https://star-history.dera.page/#Fosowl/agenticSeek&Date)

--- a/README_PTBR.md
+++ b/README_PTBR.md
@@ -691,4 +691,4 @@ Confira [Contributing.md](./docs/CONTRIBUTING.md) para aprender como integrar fe
 
  > [tcsenpai](https://github.com/tcsenpai) e [plitc](https://github.com/plitc) por ajudar na dockerização do backend
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fosowl/agenticSeek&type=Date)](https://www.star-history.com/#Fosowl/agenticSeek&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fosowl/agenticSeek&type=Date)](https://star-history.dera.page/#Fosowl/agenticSeek&Date)

--- a/README_TR.md
+++ b/README_TR.md
@@ -701,4 +701,4 @@ AgenticSeek'in yeteneklerini uçuş arama, seyahat planlama veya en iyi alışve
 
  > [tcsenpai](https://github.com/tcsenpai) ve [plitc](https://github.com/plitc) Backend dockerizasyonuna yardımları için
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fosowl/agenticSeek&type=Date)](https://www.star-history.com/#Fosowl/agenticSeek&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fosowl/agenticSeek&type=Date)](https://star-history.dera.page/#Fosowl/agenticSeek&Date)


### PR DESCRIPTION
The star history chart in the READMEs is currently broken due to GitHub stargazer API restrictions. This change points the chart to a working alternative so it renders correctly again.