### PR TITLE
fix(browser): import ElementClickInterceptedException — the JS-click fallback for intercepted checkboxes never runs

### DIFF
--- a/sources/browser.py
+++ b/sources/browser.py
@@ -4,7 +4,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait, Select
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.common.exceptions import TimeoutException, WebDriverException
+from selenium.common.exceptions import ElementClickInterceptedException, TimeoutException, WebDriverException
 from selenium.webdriver.common.action_chains import ActionChains
 from typing import List, Tuple, Type, Dict
 from bs4 import BeautifulSoup


### PR DESCRIPTION
## Problem

`sources/browser.py` catches `ElementClickInterceptedException` in two places but never imports it:

```python
# line 7 — the only selenium.common.exceptions import
from selenium.common.exceptions import TimeoutException, WebDriverException
```

```
$ pyflakes sources/browser.py
sources/browser.py:491:20: undefined name 'ElementClickInterceptedException'
sources/browser.py:649:32: undefined name 'ElementClickInterceptedException'
```

Python evaluates the exception expression in an `except` clause **only when an
exception actually propagates to it**, so this never fails at import time — it
fails exactly when a click gets intercepted, which is the common case on pages
with a cookie banner or a sticky overlay.

Worse, both sites are wrapped in a broad `except Exception`, so the `NameError`
is swallowed and only shows up as a misleading log line.

**`tick_all_checkboxes` (line 645-659)** is the more damaging one — the handler
is the JS-click fallback, the standard remedy for an intercepted click:

```python
if not checkbox.is_selected():
    try:
        checkbox.click()
        self.logger.info(f"Ticked checkbox {index}")
    except ElementClickInterceptedException:                       # NameError here
        self.driver.execute_script("arguments[0].click();", checkbox)
        self.logger.warning(f"Click checkbox {index} intercepted")
except Exception as e:
    self.logger.error(f"Error ticking checkbox {index}: {str(e)}")  # swallows it
    continue
```

So an intercepted checkbox is **never** ticked by the fallback; the loop just
logs `Error ticking checkbox N: name 'ElementClickInterceptedException' is not
defined` and moves on.

**`click_element` (line 491)** degrades the same way: the specific
`return False` handler is skipped and the outer `except Exception` logs
`Unexpected error clicking element at {xpath}` with the `NameError` text instead
of the real cause.

## Reproduction

Faithful reduction of the `tick_all_checkboxes` inner loop, run with and without
the import:

```
BEFORE (import missing, as on main):
  ERROR Error ticking checkbox 1: name 'ElementClickInterceptedException' is not defined
  -> checkbox ticked: False
AFTER  (import added):
  WARNING Click checkbox 1 intercepted
  -> checkbox ticked: True
```

## Fix

Add `ElementClickInterceptedException` to the existing
`selenium.common.exceptions` import. One line.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
