### PR TITLE
fix(memory): initialize compression before recovering a session

### DIFF
--- a/sources/memory.py
+++ b/sources/memory.py
@@ -32,9 +32,6 @@ class Memory():
         self.session_id = str(uuid.uuid4())
         self.conversation_folder = runtime_subdir("conversations")
         self.session_recovered = False
-        if recover_last_session:
-            self.load_memory()
-            self.session_recovered = True
         # memory compression system
         self.model = None
         self.tokenizer = None
@@ -43,6 +40,9 @@ class Memory():
         self.model_provider = model_provider
         if self.memory_compression:
             self.download_model()
+        if recover_last_session:
+            self.load_memory()
+            self.session_recovered = True
 
     def get_ideal_ctx(self, model_name: str) -> int | None:
         """

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -3,6 +3,7 @@ import os
 import sys
 import json
 import datetime
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))  # Add project root to Python path
 from sources.memory import Memory
@@ -84,10 +85,27 @@ class TestMemory(unittest.TestCase):
         self.memory.push("assistant", "Hi")
         self.memory.save_memory()
         
-        new_memory = Memory(self.system_prompt, recover_last_session=True)
+        new_memory = Memory(
+            self.system_prompt, recover_last_session=True, memory_compression=False
+        )
         new_memory.load_memory()
         self.assertEqual(len(new_memory.memory), 3)  # System + messages
         self.assertEqual(new_memory.memory[1]['content'], "Hello")
+
+    def test_recovered_memory_is_compressed_after_model_initialization(self):
+        self.memory.push("assistant", "Saved response. " * 100)
+        self.memory.save_memory()
+
+        # Keep the real download/restore/compress flow, but avoid network and inference.
+        with patch("sources.memory.AutoTokenizer.from_pretrained") as tokenizer_loader, \
+                patch("sources.memory.AutoModelForSeq2SeqLM.from_pretrained"):
+            tokenizer_loader.return_value.return_value = {"input_ids": [1, 2, 3]}
+            tokenizer_loader.return_value.decode.return_value = "Recovered summary"
+            restored = Memory(self.system_prompt, recover_last_session=True)
+
+        self.assertEqual(restored.memory[0]["content"], self.system_prompt)
+        self.assertEqual(restored.memory[1]["content"], "Recovered summary")
+        self.assertTrue(restored.session_recovered)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Calling `Memory(..., recover_last_session=True)` with a saved conversation raises `AttributeError: 'Memory' object has no attribute 'tokenizer'`, even with `memory_compression=False`. The constructor calls `load_memory()`, which calls `compress()`, before the compression fields are initialized.

Move the existing recovery block after compression initialization. With compression disabled, saved messages load unchanged; with it enabled, the initialized model can summarize restored content. This targets the constructor recovery flag; the application's agents already construct Memory first and restore through Interaction afterward.

The existing save/load test now disables model downloads. A second regression exercises enabled compression through the real restore/compress flow, replacing only external tokenizer/model loading and inference with test doubles. No persistence format, dependency, or API changes.

Validation on base `bffa7e9e94294f7937c733014af062351c6d6420`:

- The same two recovery regressions fail before the fix with the missing-tokenizer error and pass afterward.
- `python -m pytest tests/test_memory.py tests/test_logger.py tests/test_utility.py -q`: **24 passed**.
- `python -m compileall -q sources/memory.py tests/test_memory.py` and `git diff --check`: passed.

Tests ran with an isolated `AGENT_RUNTIME_DIR` and `HF_HUB_OFFLINE=1`. Full application, browser, audio, and live model integration tests were not run; validation covers the complete Memory suite and its logger/utility dependencies. The patch changes 2 files (+22/-4).
